### PR TITLE
398 ae2 facade cannot be crafted

### DIFF
--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -2,7 +2,7 @@
 
 const registerAE2Recipes = (event) => {
     
-    // Удаление рецептов мода
+    //Удаление рецептов мода
     event.remove({ not: [
         { id: 'ae2:transform/entangled_singularity_from_pearl' },
         { id: 'ae2:transform/fluix_crystals' },
@@ -12,6 +12,7 @@ const registerAE2Recipes = (event) => {
         { id: 'ae2:network/blocks/pattern_providers_interface_alt' },
         { id: 'ae2:network/blocks/interfaces_interface_part' },
         { id: 'ae2:network/blocks/interfaces_interface_alt' },
+        { id: 'ae2:special/facade'},
     ], mod: 'ae2' });
 
     //#region Рецепты энтропии

--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -2,7 +2,7 @@
 
 const registerAE2Recipes = (event) => {
     
-    //Удаление рецептов мода
+    // Удаление рецептов мода
     event.remove({ not: [
         { id: 'ae2:transform/entangled_singularity_from_pearl' },
         { id: 'ae2:transform/fluix_crystals' },


### PR DESCRIPTION
## Что
 фикс  отсутствия крафта декоративной панели ае2
fix for lack of crafting of decorative panel ae2

## Детали реализации
пофиксил отсутствие крафта декоративных панелей из мода ае2
fixed the lack of crafting decorative panels from the ae2 mod



## Исход
#398 теперь есть крафт

До: #398
после: 
![image](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/assets/112543401/dc1ed80c-c199-476c-a550-736efffdbd71)
