### PR TITLE
fix long distance pipelines

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1252,6 +1252,31 @@ const registerGTCEURecipes = (event) => {
 
     //#endregion
 
+    //#region Long Distance Pipelines
+
+    event.remove({ id: 'gtceu:assembler/long_distance_item_pipe'  })
+    event.recipes.gtceu.assembler('long_distance_item_pipe')
+        .itemInputs(
+            '1x gtceu:tin_large_item_pipe',
+            '4x #forge:plates/steel')
+        .inputFluids(Fluid.of('gtceu:soldering_alloy', 144 / 4))
+        .itemOutputs('32x gtceu:long_distance_item_pipeline')
+        .circuit(2)
+        .duration(300)
+        .EUt(24)
+
+    event.remove({ id: 'gtceu:assembler/long_distance_fluid_pipe'  })
+    event.recipes.gtceu.assembler('long_distance_fluid_pipe')
+        .itemInputs(
+            '1x gtceu:bronze_large_fluid_pipe',
+            '4x #forge:plates/steel')
+        .inputFluids(Fluid.of('gtceu:soldering_alloy', 144 / 4))
+        .itemOutputs('32x gtceu:long_distance_fluid_pipeline')
+        .circuit(2)
+        .duration(300)
+        .EUt(24)
+
+    //#endregion
 
     //#region Рецепты, которые итерируются по всем материалам
 


### PR DESCRIPTION
# What

Fix issue for uncraftable assembler recipes, namely Long Distance Fluid/Item Pipelines from GT.

# Implementation Details

I remove the old recipe and add a new one, I don't know anything about kubejs, but maybe I should have modified it instead? Anyway the fix was halfing all the inputs and outputs of the recipe. The Long Distance Pipelines only stack up to 32.

# Outcome

Fixes #489, #314 and #361.

# Additional Information

None.

# Potential Compatibility Issues

Probably none, I've seen in the latest version of GregTech the recipe didn't change.
