### PR TITLE
fix #436

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1094,7 +1094,7 @@ const registerCreateRecipes = (event) => {
     ]).ingredient('#tfc:leather_knapping').id('tfg:create/shaped/belt_connector')
 
     event.recipes.gtceu.assembler('tfg:create/belt_connector')             
-        .itemInputs('minecraft:leather')
+        .itemInputs('#forge:leather')
         .circuit(2)
         .itemOutputs('create:belt_connector')
         .duration(25)

--- a/kubejs/server_scripts/minecraft/recipes.js
+++ b/kubejs/server_scripts/minecraft/recipes.js
@@ -2268,7 +2268,7 @@ const registerMinecraftRecipes = (event) => {
     event.remove({ id: 'gtceu:extractor/bookshelf_extraction' })
 
     event.shapeless('minecraft:book', [
-        'minecraft:paper', 'minecraft:paper', 'minecraft:paper', 'minecraft:leather'
+        'minecraft:paper', 'minecraft:paper', 'minecraft:paper', '#forge:leather'
     ]).id('minecraft:book')
 
     //#endregion
@@ -2594,7 +2594,7 @@ const registerMinecraftRecipes = (event) => {
     event.remove({ id: 'minecraft:item_frame' })
 
     event.recipes.gtceu.assembler('item_frame')             
-        .itemInputs('8x #tfc:lumber', 'minecraft:leather')
+        .itemInputs('8x #tfc:lumber', '#forge:leather')
         .itemOutputs('8x minecraft:item_frame')
         .duration(100)
         .EUt(4)


### PR DESCRIPTION
Заменены использования предмета minecraft:leather на тэг #forge:leather для починки рецептов книги и в ассемблере.

Рецепт глайдера не трогал, предполагаю, что он будет изменён.