### PR TITLE
fix #520

### DIFF
--- a/kubejs/server_scripts/create_connected/recipes.js
+++ b/kubejs/server_scripts/create_connected/recipes.js
@@ -71,4 +71,6 @@ const registerCreateConnectedRecipes = (event) => {
         .itemOutputs('create_connected:control_chip')
         .duration(720)
         .EUt(16)
+
+    event.remove({ input: 'create:copper_sheet'})
 }


### PR DESCRIPTION
Hide all recipe with disabled "create:copper_sheet" item so broken "Fluid vessel" no more shown.
