### PR TITLE
TFC Stone Hammer Restoration

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -2759,31 +2759,6 @@ const registerTFCRecipes = (event) => {
 
     //#endregion
 
-    //#region Молот
-
-    // Инструмент
-    event.remove({ id: `tfc:crafting/stone/hammer_igneous_extrusive` })
-    event.remove({ id: `tfc:crafting/stone/hammer_igneous_intrusive` })
-    event.remove({ id: `tfc:crafting/stone/hammer_metamorphic` })
-    event.remove({ id: `tfc:crafting/stone/hammer_sedimentary` })
-
-    // Оголовья
-    event.remove({ id: `tfc:rock_knapping/hammer_head_igneous_extrusive` })
-    event.remove({ id: `tfc:rock_knapping/hammer_head_igneous_intrusive` })
-    event.remove({ id: `tfc:rock_knapping/hammer_head_metamorphic` })
-    event.remove({ id: `tfc:rock_knapping/hammer_head_sedimentary` })
-
-    event.recipes.tfc.knapping('gtceu:stone_hammer_head', 'tfc:rock', [
-            "XXXXX",
-            "XXXXX",
-            "  X  "
-        ])
-        .ingredient('#tfc:rock_knapping')
-        .outsideSlotRequired(false)
-        .id('tfg:rock_knapping/stone_hammer_head')
-
-    //#endregion
-
     //#region Мотыга
 
     // Инструмент

--- a/kubejs/startup_scripts/gtceu/constants.js
+++ b/kubejs/startup_scripts/gtceu/constants.js
@@ -45,6 +45,9 @@ global.GTCEU_DISABLED_ITEMS = [
     'gtceu:rubber_log', 
     'gtceu:rubber_leaves', 
     'gtceu:rubber_planks',
+
+    'gtceu:stone_hammer_head',
+    'gtceu:stone_hammer'
     
 ];
 

--- a/kubejs/startup_scripts/tfc/constants.js
+++ b/kubejs/startup_scripts/tfc/constants.js
@@ -629,16 +629,6 @@ global.TFC_DISABLED_ITEMS = [
     'tfc:stone/shovel/metamorphic', 
     'tfc:stone/shovel/sedimentary', 
     
-    'tfc:stone/hammer_head/igneous_extrusive', 
-    'tfc:stone/hammer_head/igneous_intrusive', 
-    'tfc:stone/hammer_head/metamorphic', 
-    'tfc:stone/hammer_head/sedimentary', 
-    
-    'tfc:stone/hammer/igneous_extrusive', 
-    'tfc:stone/hammer/igneous_intrusive', 
-    'tfc:stone/hammer/metamorphic', 
-    'tfc:stone/hammer/sedimentary', 
-    
     'tfc:stone/hoe_head/igneous_extrusive', 
     'tfc:stone/hoe_head/igneous_intrusive', 
     'tfc:stone/hoe_head/metamorphic', 


### PR DESCRIPTION
What
Restores the recipes for the Terrafirmacraft Stone Hammer, undoing the replacement with gregtech's stone hammer. This is necessary as the gregtech stone hammer allows players to skip terrafirmacraft progression by mining with it as soon as they can knap stones together.

Implementation Details
Before Pulling, verify that changes retain full gameplay functionality of the hammer while preventing players from mining ore before casting their first pickaxe.

Outcome
Disables GTCEU stone hammer via disabled-items constant list.
Removes TFC stone hammer from disabled-items constant list, restoring its tags and functionality
Removes TFC stone hammer recipe interference/replacement from TFC recipe.js, returning the original recipe to the game and removing the only way to craft the GTCEU stone hammer (as it is no longer necessary)

Potential Compatibility Issues
Save files which already have Gregtech Stone Hammers will find them unusable and unobtainable, but not truly removed from the game.