### PR TITLE
Added quern recipes for graphite

### DIFF
--- a/kubejs/startup_scripts/tfc/constants.js
+++ b/kubejs/startup_scripts/tfc/constants.js
@@ -967,6 +967,9 @@ global.TFC_QUERN_POWDER_RECIPE_COMPONENTS = [
     { input: '#forge:dusts/borax', output: '4x tfc:powder/flux', name: 'flux_powder' },
     { input: '#forge:dusts/soda_ash', output: '4x tfc:powder/soda_ash', name: 'soda_ash' },
     { input: 'minecraft:charcoal', output: '2x tfc:powder/charcoal', name: 'charcoal' },
+    { input: 'gtceu:raw_graphite', output: 'gtceu:graphite_dust', name: 'raw_graphite_to_dust' },
+    { input: 'gtceu:poor_raw_graphite', output: '5x gtceu:tiny_graphite_dust', name: 'poor_raw_graphite_to_dust' },
+    { input: 'gtceu:rich_raw_graphite', output: '2x gtceu:graphite_dust', name: 'rich_graphite_to_dust' },
 ];
 
 global.TFC_QUERN_GRAIN_RECIPE_COMPONENTS = [


### PR DESCRIPTION
Added quern recipes for graphite, because "why can't I use my raw graphite to make kaolin clay" is a frequent question in the discord.

They have the same results as the furnace.

![image](https://github.com/user-attachments/assets/2bc4ca1a-cbcd-4236-b711-e0846f4f6347)
![image](https://github.com/user-attachments/assets/4c71e362-f1d0-48d1-b194-5ec124e8ec95)
![image](https://github.com/user-attachments/assets/1db8a088-16d3-46a9-bc96-237fecc6821c)
