### PR TITLE
Fixed red alloy crucible recipe

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -1286,8 +1286,8 @@ const registerTFCRecipes = (event) => {
     //#region Рецепты для новых сплавов
 
     event.recipes.tfc.alloy('tfg:red_alloy', [
-        TFC.alloyPart('tfg:redstone', 0.15, 0.25),
-        TFC.alloyPart('tfc:copper', 0.75, 0.85)
+        TFC.alloyPart('tfg:redstone', 0.75, 0.85),
+        TFC.alloyPart('tfc:copper', 0.15, 0.25)
     ]).id('tfg:alloy/red_alloy')
 
     event.recipes.tfc.alloy('tfg:tin_alloy', [


### PR DESCRIPTION
Fixed the crucible recipe for Red Alloy to be the same as gregtech (1 copper + 4 redstone)

![image](https://github.com/user-attachments/assets/9c902b81-429c-4d45-b155-cf36590f150c)
