### PR TITLE
fix rod rolling output amount

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -145,7 +145,7 @@ const registerGregTechRecipes = (e) => {
     }
 
     const processRod = (tagPrefix, material) => {
-        const rodItem = ChemicalHelper.get(tagPrefix, material, 1)
+        const rodItem = ChemicalHelper.get(tagPrefix, material, 2)
         if (rodItem.isEmpty()) return
         
         const ingotItem = ChemicalHelper.get(TagPrefix.ingot, material, 1)


### PR DESCRIPTION
## What is the new behavior?

Fixes issue #636, sets output amount of rod rolling recipes to 2

## Implementation Details

Changed output of rolling mill rod recipes to be consistent with 0.7.14

## Outcome

Fixes: #636 
