### PR TITLE
precision mech in assembler

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1185,4 +1185,15 @@ const registerCreateRecipes = (event) => {
     })
 
     //#endregion
+
+    //#region Механизм точности
+
+    e.recipes.gtceu.assembler('tfg:create/precision_mechanism')
+    .itemInputs('#forge:sheets/gold','3x create:cogwheel', '3x create:large_cogwheel', '3x #forge:nuggets/iron')
+    .itemOutputs('create:precision_mechanism')
+    .duration(2000)
+    .EUt(20)
+
+    //#endregion
+    
 }


### PR DESCRIPTION
Механизм точности в ассемблере, потому что стандартный рецепт креэйта боль, тем более когда ты уже в весь в грегтехе

The precision mechanism is in assembler, because the standard recipe for create is a pain, especially when you are already in full at gregtech

![image](https://github.com/user-attachments/assets/6fd6f3e5-1876-4873-9bb7-320e2fdb608d)
