### PR TITLE
Fix LV recycling recipes to produce basic steel.

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1457,4 +1457,26 @@ const registerGTCEURecipes = (event) => {
     });
 
     //#endregion
+
+    // Fix LV recycling producing red/blue steel.
+    // Replace red steel outputs with 8x steel, delete blue steel outputs.
+    event.replaceOutput(
+        /gtceu:arc_furnace\/arc_lv_.*/,
+        '#forge:ingots/red_steel',
+        '8x #forge:ingots/steel')
+
+    event.replaceOutput(
+        /gtceu:arc_furnace\/arc_lv_.*/,
+        '#forge:ingots/blue_steel',
+        '')
+
+    event.replaceOutput(
+        /gtceu:macerator\/macerate_lv_.*/,
+        '#forge:dusts/red_steel',
+        '8x #forge:dusts/steel')
+
+    event.replaceOutput(
+        /gtceu:macerator\/macerate_lv_.*/,
+        '#forge:dusts/blue_steel',
+        '')
 }


### PR DESCRIPTION
## What is the new behavior?

This changes all arc furnace and macerator recycling recipes for LV machines to output steel ingots / dusts instead of red / blue steel. An alternative to @Pyritie's #643 :-) 

## Implementation Details

You can match recipe IDs by regexp, yay.

## Outcome

No more exploits. 