### PR TITLE
Added recipes to stop duping of red alloy + steam machines

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1506,4 +1506,153 @@ const registerGTCEURecipes = (event) => {
         // Craft super chests to remove their NBT data.
         event.shapeless(`gtceu:${prefix}_chest`, [`gtceu:${prefix}_chest`])
     });
+
+    //#region fix more duping
+	
+	// red alloy, because crucible always makes 4+1=5
+	
+	event.remove({id: 'gtceu:mixer/red_alloy' })
+	event.recipes.gtceu.mixer('tfg:red_alloy_mixer')
+		.itemInputs('1x gtceu:copper_dust', '4x minecraft:redstone')
+		.itemOutputs('5x gtceu:red_alloy_dust')
+		.circuit(2)
+		.duration(100)
+		.EUt(7)
+	
+	event.remove({id: 'gtceu:centrifuge/red_alloy_separation' })
+	event.recipes.gtceu.centrifuge('tfg:red_alloy_separation')
+		.itemInputs('5x gtceu:red_alloy_dust')
+		.itemOutputs('1x gtceu:copper_dust', '4x minecraft:redstone')
+		.duration(900)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:alloy_smelter/copper_dust_and_redstone_dust_into_red_alloy' })
+	event.recipes.gtceu.alloy_smelter('tfg:copper_dust_and_redstone_dust_into_red_alloy')
+		.itemInputs('1x gtceu:copper_dust', '4x minecraft:redstone')
+		.itemOutputs('5x gtceu:red_alloy_ingot')
+		.duration(50)
+		.EUt(16)
+		
+	event.remove({id: 'gtceu:alloy_smelter/annealed_copper_dust_and_redstone_dust_into_red_alloy' })
+	event.recipes.gtceu.alloy_smelter('tfg:annealed_copper_dust_and_redstone_dust_into_red_alloy')
+		.itemInputs('1x gtceu:annealed_copper_dust', '4x minecraft:redstone')
+		.itemOutputs('5x gtceu:red_alloy_ingot')
+		.duration(50)
+		.EUt(16)
+		
+	event.remove({id: 'gtceu:alloy_smelter/copper_ingot_and_redstone_dust_into_red_alloy' })
+	event.recipes.gtceu.alloy_smelter('tfg:copper_ingot_and_redstone_dust_into_red_alloy')
+		.itemInputs('1x minecraft:copper_ingot', '4x minecraft:redstone')
+		.itemOutputs('5x gtceu:red_alloy_ingot')
+		.duration(50)
+		.EUt(16)
+		
+	event.remove({id: 'gtceu:alloy_smelter/annealed_copper_ingot_and_redstone_dust_into_red_alloy' })
+	event.recipes.gtceu.alloy_smelter('tfg:annealed_copper_ingot_and_redstone_dust_into_red_alloy')
+		.itemInputs('1x gtceu:annealed_copper_ingot', '4x minecraft:redstone')
+		.itemOutputs('5x gtceu:red_alloy_ingot')
+		.duration(50)
+		.EUt(16)
+	
+	// steam machines
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_forge_hammer' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_forge_hammer')
+		.itemInputs('1x gtceu:hp_steam_forge_hammer')
+		.itemOutputs('8x gtceu:wrought_iron_ingot', '3x gtceu:steel_ingot', '2x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_forge_hammer' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_forge_hammer')
+		.itemInputs('1x gtceu:hp_steam_forge_hammer')
+		.itemOutputs('8x gtceu:iron_dust', '3x gtceu:steel_dust', '2x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_extractor' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_extractor')
+		.itemInputs('1x gtceu:hp_steam_extractor')
+		.itemOutputs('7x gtceu:wrought_iron_ingot', '2x gtceu:steel_ingot', '3x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_extractor' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_extractor')
+		.itemInputs('1x gtceu:hp_steam_extractor')
+		.itemOutputs('7x gtceu:iron_dust', '2x gtceu:steel_dust', '3x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_macerator' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_macerator')
+		.itemInputs('1x gtceu:hp_steam_macerator')
+		.itemOutputs('8x gtceu:wrought_iron_ingot', '3x gtceu:steel_ingot', '2x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_macerator' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_macerator')
+		.itemInputs('1x gtceu:hp_steam_macerator')
+		.itemOutputs('8x gtceu:iron_dust', '3x gtceu:steel_dust', '2x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_compressor' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_compressor')
+		.itemInputs('1x gtceu:hp_steam_compressor')
+		.itemOutputs('7x gtceu:wrought_iron_ingot', '1x gtceu:steel_ingot', '5x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_compressor' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_compressor')
+		.itemInputs('1x gtceu:hp_steam_compressor')
+		.itemOutputs('7x gtceu:iron_dust', '1x gtceu:steel_dust', '5x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_furnace' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_furnace')
+		.itemInputs('1x gtceu:hp_steam_furnace')
+		.itemOutputs('7x gtceu:wrought_iron_ingot', '2x gtceu:steel_ingot', '4x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_furnace' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_furnace')
+		.itemInputs('1x gtceu:hp_steam_furnace')
+		.itemOutputs('7x gtceu:iron_dust', '2x gtceu:steel_dust', '4x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_alloy_smelter' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_alloy_smelter')
+		.itemInputs('1x gtceu:hp_steam_alloy_smelter')
+		.itemOutputs('11x gtceu:wrought_iron_ingot', '1x gtceu:steel_ingot', '1x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_alloy_smelter' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_alloy_smelter')
+		.itemInputs('1x gtceu:hp_steam_alloy_smelter')
+		.itemOutputs('11x gtceu:iron_dust', '1x gtceu:steel_dust', '1x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+		
+	event.remove({id: 'gtceu:arc_furnace/arc_hp_steam_rock_crusher' })
+	event.recipes.gtceu.arc_furnace('tfg:arc_hp_steam_rock_crusher')
+		.itemInputs('1x gtceu:hp_steam_rock_crusher')
+		.itemOutputs('10x gtceu:wrought_iron_ingot', '1x gtceu:steel_ingot', '2x gtceu:tin_alloy_ingot')
+		.duration(3310)
+		.EUt(30)
+		
+	event.remove({id: 'gtceu:macerator/macerate_hp_steam_rock_crusher' })
+	event.recipes.gtceu.macerator('tfg:macerate_hp_steam_rock_crusher')
+		.itemInputs('1x gtceu:hp_steam_rock_crusher')
+		.itemOutputs('10x gtceu:iron_dust', '1x gtceu:steel_dust', '2x gtceu:tin_alloy_dust', '12x gtceu:brick_dust')
+		.duration(3254)
+		.EUt(8)
+	
+	//#endregion
 }


### PR DESCRIPTION
Crucible always does 1 copper + 4 redstone = 5 red alloy, so to prevent duping, I changed the gregtech recipes to match.

![image](https://github.com/user-attachments/assets/0c172a4c-60c5-43af-8661-09f3ffaf0a5d)
![image](https://github.com/user-attachments/assets/a89cf42c-dda1-4135-a508-76157a460321)
![image](https://github.com/user-attachments/assets/c7933088-377e-4bba-bb37-d5877090fa93)

I also fixed the arc furnace + macerator recipes for steam machines so they return the correct items.
![image](https://github.com/user-attachments/assets/744dd373-6cf0-4157-85e0-23945011f1f3)
![image](https://github.com/user-attachments/assets/a6ff6cf6-283e-4318-9ac0-1a3e37c9f46b)

etc