### PR TITLE
Adds early glowstone recipe

### DIFF
--- a/kubejs/server_scripts/minecraft/recipes.js
+++ b/kubejs/server_scripts/minecraft/recipes.js
@@ -3258,4 +3258,16 @@ const registerMinecraftRecipes = (event) => {
     event.remove({ id: 'minecraft:raw_iron' })
 
     //#endregion
+
+    //#region Glowstone
+
+    event.recipes.gtceu.mixer('gtceu:lv_glowstone')
+		.inputFluids(Fluid.of('gtceu:creosote', 1000), Fluid.of('gtceu:distilled_water', 1000))
+		.itemInputs('gtceu:stone_dust', 'minecraft:redstone', 'gtceu:sulfur_dust', 'gtceu:sodium_dust')
+		.itemOutputs('minecraft:glowstone_dust')
+		.circuit(32)
+		.duration(1200)
+		.EUt(32)
+
+    //#endregion
 }


### PR DESCRIPTION
Added an early glowstone recipe so people can have light bulbs at the same time they have electricity.
It's intentionally annoying so the hv macerator recipe is better once that is available.

![image](https://github.com/user-attachments/assets/e22a3663-922f-4933-9daa-4759304b6306)

Stone Dust (from ore washing) + redstone + sulfur + sodium + 1B creosote + 1B distilled water = 1 glowstone dust