### PR TITLE
Remove ore spreadsheet link from field guide

### DIFF
--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/ore_basics.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/ore_basics.json
@@ -53,7 +53,7 @@
 		},
 		{
 			"type": "patchouli:text",
-			"text": "Later, when you're in LV, check the LV quests to learn about all the different ore processing machines and extra byproducts they can give you. Remember the $(thing)Macerator$() does not give byproducts until $(thing)HV$()!$(br2)Here's a $(l:https://docs.google.com/spreadsheets/d/1P3Baz4y5vgJ3XrCoNs4l3BXGPiFEPlW7i4taPEWpTB4/edit?usp=sharing)Spreadsheet$() if you prefer to see this section's ore generation data that way."
+			"text": "Later, when you're in LV, check the LV quests to learn about all the different ore processing machines and extra byproducts they can give you. Remember the $(thing)Macerator$() does not give byproducts until $(thing)HV$()!"
 		}
 	]
 }


### PR DESCRIPTION
Removed the ore spreadsheet link from field guide, as per #675