### PR TITLE
Added greenhouse recipes for tfc plants tag

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -2982,6 +2982,14 @@ const registerTFCRecipes = (event) => {
         generateGreenHouseRecipe(event, element.input, element.fluid_amount, element.output, element.name)
     })
 
+    // Растения
+    Ingredient.of('#tfc:plants').stacks.forEach(element => {
+        const itemId = element.id;
+        const recipeId = `greenhouse_${itemId.replace(':', '_')}`;
+    
+        generateGreenHouseRecipe(event, itemId, 8000, `8x ${itemId}`, recipeId);
+    });
+
     //#endregion
 
     //#region Рецепты плоского теста


### PR DESCRIPTION
## What is the new behavior?
Added recipes for growing #tfc:plants in greenhouse. For decoration purposes

## Implementation Details
Reused generateGreenhouseRecipe in kubeJS iterating over tag #tfc:plants

## Outcome
Now all plants can be grown in greenhouse. 

## Additional Information
![image](https://github.com/user-attachments/assets/a5255911-ca3a-4381-a61b-472d2267a5f2)

## Potential Compatibility Issues
Probable not, maybe some intersections of recipes in future if tags will have same plants