### PR TITLE
Creosote treated planks fixes

### DIFF
--- a/kubejs/server_scripts/gregtech/tags.js
+++ b/kubejs/server_scripts/gregtech/tags.js
@@ -39,6 +39,8 @@ const registerGTCEUItemTags = (event) => {
 
     event.add('tfg:stone_dusts', 'gtceu:stone_dust')
 
+	event.remove('minecraft:planks', 'gtceu:treated_wood_planks')
+    
     //#endregion
 }
 


### PR DESCRIPTION
- Stops creosote treated planks from eating all the creosote in a barrel
- Allows treated wood pipes to be crafted
#473