### PR TITLE
Fix sprinklers + fix bread and yeast starter recipe conflict

### DIFF
--- a/defaultconfigs/firmalife-server.toml
+++ b/defaultconfigs/firmalife-server.toml
@@ -1,0 +1,6 @@
+
+[general]
+	#If true, the tumbler and the pumping station work magically with a redstone signal and no power required.
+	mechanicalPowerCheatMode = true
+	#If true, sprinkler will not accept firmalife pipes and will instead require something that exposes a fluid capability, eg. a barrel.
+	usePipesForSprinklers = false

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/firmalife/irrigation.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/firmalife/irrigation.json
@@ -1,0 +1,62 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Irrigation",
+  "category": "tfc:firmalife",
+  "icon": "firmalife:sprinkler",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "The $(thing)Sprinkler$() is a device that sprinkles water in a 5x6x5 area centered on the block below the sprinkler block. You know it is working when it drips out water particles. Sprinklers placed facing up irrigate the same 5x6x5 area above."
+    },
+    {
+      "type": "tfc:anvil_recipe",
+      "recipe": "firmalife:anvil/sprinkler",
+      "text": "The sprinkler is made with a $(thing)Copper Plate$()."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Sprinklers must be connected to a system of pipes that feed it water in order to work. This is done by connecting a series of $(thing)Copper Pipes$() to them. Copper Pipes transport water up to 32 blocks to a sprinkler. They are connected to $(thing)Pumping Stations$()."
+    },
+    {
+      "type": "tfc:anvil_recipe",
+      "recipe": "firmalife:anvil/copper_pipe",
+      "text": "The copper pipe is made with a plate."
+    },
+    {
+      "type": "patchouli:multiblock",
+      "multiblock": {
+        "pattern": [
+          [
+            "X"
+          ],
+          [
+            "0"
+          ]
+        ],
+        "mapping": {
+          "X": "firmalife:pumping_station"
+        }
+      },
+      "name": "",
+      "text": "",
+      "enable_visualize": false
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfg:shaped/pumping_station",
+      "text": "Pumping stations must be above a source block of water in order to work. Activate them with a redstone signal."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "firmalife:crafting/oxidized_copper_pipe",
+      "text": "Oxidized pipes are the same as regular copper pipes, except they do not connect to the other kind of pipe."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "firmalife:crafting/greenhouse/iron_greenhouse_port",
+      "text": "Greenhouse ports have a single pipe inside of them. They can be used to pass water through the walls of greenhouses!"
+    }
+  ],
+  "read_by_default": true,
+  "sortnum": 8
+}

--- a/kubejs/server_scripts/firmalife/recipes.js
+++ b/kubejs/server_scripts/firmalife/recipes.js
@@ -393,6 +393,7 @@ const registerFirmaLifeRecipes = (event) => {
             .itemOutputs(element.output)
             .duration(300)
             .EUt(16)
+        	.circuit(2)
     })
 
     //#endregion

--- a/kubejs/server_scripts/firmalife/recipes.js
+++ b/kubejs/server_scripts/firmalife/recipes.js
@@ -134,6 +134,32 @@ const registerFirmaLifeRecipes = (event) => {
     //#region Рецепты теплиц
 
     //#region Медная
+	
+	event.shaped('firmalife:pumping_station',
+	[
+		' B ',
+		'ACA',
+		' D '
+	], {
+        A: 'firmalife:copper_pipe',
+		B: 'gtceu:bronze_plate',
+		C: '#tfc:barrels',
+		D: 'create:mechanical_pump'
+    }).id('tfg:shaped/pumping_station')
+	
+	event.recipes.gtceu.bender('tfg:firmalife/copper_pipe')
+		.itemInputs('gtceu:copper_plate')
+		.itemOutputs('8x firmalife:copper_pipe')
+		.circuit(3)
+		.duration(40)
+		.EUt(8)
+		
+	event.recipes.gtceu.bender('tfg:firmalife/sprinkler')
+		.itemInputs('gtceu:copper_plate')
+		.itemOutputs('firmalife:sprinkler')
+		.circuit(4)
+		.duration(60)
+		.EUt(8)
 
     // Стена
     event.shaped('8x firmalife:copper_greenhouse_wall', [
@@ -204,7 +230,7 @@ const registerFirmaLifeRecipes = (event) => {
     }).id('firmalife:crafting/greenhouse/copper_greenhouse_door')
 
     // Порт
-    event.shaped('8x firmalife:copper_greenhouse_port', [
+    event.shaped('firmalife:copper_greenhouse_port', [
         'AA',
         'BC',
         'AA' 
@@ -287,7 +313,7 @@ const registerFirmaLifeRecipes = (event) => {
     }).id('firmalife:crafting/greenhouse/iron_greenhouse_door')
 
     // Порт
-    event.shaped('8x firmalife:iron_greenhouse_port', [
+    event.shaped('firmalife:iron_greenhouse_port', [
         'AA',
         'BC',
         'AA' 
@@ -411,6 +437,7 @@ const registerFirmaLifeRecipes = (event) => {
         .itemOutputs('firmalife:food/pumpkin_pie_dough')
         .duration(300)
         .EUt(16)
+        .circuit(2)
 
     event.recipes.create.mixing('firmalife:food/pumpkin_pie_dough', ['#tfc:sweetener', '#forge:eggs', '2x tfc:food/pumpkin_chunks', '#tfc:foods/flour', Fluid.of('minecraft:water', 1000)]
     ).id('firmalife:create/mixer/food/pumpkin_pie_dough')
@@ -433,6 +460,7 @@ const registerFirmaLifeRecipes = (event) => {
         .itemOutputs('firmalife:food/pie_dough')
         .duration(300)
         .EUt(16)
+        .circuit(2)
 
     event.recipes.create.mixing('firmalife:food/pie_dough', ['#tfc:sweetener', 'firmalife:food/butter', '#tfc:foods/flour', Fluid.of('minecraft:water', 1000)])
         .id('firmalife:create/mixer/food/pie_dough')
@@ -454,6 +482,7 @@ const registerFirmaLifeRecipes = (event) => {
         .itemOutputs('4x firmalife:food/hardtack_dough')
         .duration(300)
         .EUt(16)
+        .circuit(2)
 
     event.recipes.create.mixing('4x firmalife:food/hardtack_dough', ['tfc:powder/salt', '#tfc:foods/flour', Fluid.of('minecraft:water', 1000)])
         .id('firmalife:create/mixer/food/hardtack_dough')
@@ -465,6 +494,7 @@ const registerFirmaLifeRecipes = (event) => {
         .outputFluids('firmalife:yeast_starter', 600)
         .duration(1200)
         .EUt(8)
+        .circuit(1)
 		
 	event.recipes.create.mixing(Fluid.of('firmalife:yeast_starter', 600), ['#tfc:foods/flour', Fluid.of('firmalife:yeast_starter', 100)])
 		.id('firmalife:create/mixer/yeast_starter')

--- a/kubejs/server_scripts/firmalife/recipes.js
+++ b/kubejs/server_scripts/firmalife/recipes.js
@@ -146,6 +146,30 @@ const registerFirmaLifeRecipes = (event) => {
 		C: '#tfc:barrels',
 		D: 'create:mechanical_pump'
     }).id('tfg:shaped/pumping_station')
+
+		event.shaped('firmalife:pumping_station',
+	[
+		' B ',
+		'ACA',
+		' D '
+	], {
+        A: 'firmalife:copper_pipe',
+		B: 'gtceu:black_bronze_plate',
+		C: '#tfc:barrels',
+		D: 'create:mechanical_pump'
+    }).id('tfg:shaped/pumping_station2')
+	
+	event.shaped('firmalife:pumping_station',
+	[
+		' B ',
+		'ACA',
+		' D '
+	], {
+        A: 'firmalife:copper_pipe',
+		B: 'gtceu:bismuth_bronze_plate',
+		C: '#tfc:barrels',
+		D: 'create:mechanical_pump'
+    }).id('tfg:shaped/pumping_station3')
 	
 	event.recipes.gtceu.bender('tfg:firmalife/copper_pipe')
 		.itemInputs('gtceu:copper_plate')

--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -3001,6 +3001,7 @@ const registerTFCRecipes = (event) => {
             .itemOutputs(element.output)
             .duration(300)
             .EUt(16)
+            .circuit(3)
     })
 
     //#endregion

--- a/kubejs/startup_scripts/firmalife/constants.js
+++ b/kubejs/startup_scripts/firmalife/constants.js
@@ -33,8 +33,7 @@ global.FIRMALIFE_DISABLED_ITEMS = [
     'firmalife:metal/block/stainless_steel_slab',
 
     // Other
-    'firmalife:compost_tumbler', 
-    'firmalife:pumping_station'
+    'firmalife:compost_tumbler'
 ];
 
 global.FIRMALIFE_HIDED_ITEMS = [


### PR DESCRIPTION
## What is the new behavior?
![image](https://github.com/user-attachments/assets/e56a7147-5560-4c9e-9b82-a683a66059b4)
It Just Works™

Added recipes for the pumping station
![image](https://github.com/user-attachments/assets/bdcd5fd8-7b1b-4b74-a916-d429ca33f9c3)
Added machine recipes for the sprinkler and pipes
![image](https://github.com/user-attachments/assets/c36e522c-5975-41b8-82d4-faa95104a4cc)
![image](https://github.com/user-attachments/assets/0f3c5ee7-b0ae-4346-a3ff-f74e8dfa987b)

Also fixed #700, added circuits to those mixer recipes
Fixes #491

## Implementation Details
Update firmalife to 2.1.15

## Outcome
Sprinkler can be used

## Potential Compatibility Issues
I have not tested absolutely everything in firmalife, but I looked through the recipes and they all look ok. I did have to change two new ones they added (using different bronzes to make the pumping station)