### PR TITLE
Allows stick bundles to be used in the coke oven

### DIFF
--- a/kubejs/server_scripts/tfc/tags.js
+++ b/kubejs/server_scripts/tfc/tags.js
@@ -54,6 +54,9 @@ const registerTFCItemTags = (event) => {
         event.add('minecraft:logs_that_burn', `#tfc:${woodType}_logs`)
     })
 
+    // Allows TFC stick bundles to be burned in the coke/pyrolyse ovens
+    event.add("minecraft:logs_that_burn", "tfc:stick_bundle");
+
     // Определеяет какое оружие может появиться у зомбя/скелета в руках
     // Мечи
     event.add('tfc:mob_mainhand_weapons', 'gtceu:bismuth_bronze_sword')


### PR DESCRIPTION
## What is the new behavior?
Stick bundles can now be turned into charcoal in the coke oven and pyrolyse oven.

## Implementation Details
Stick bundles now have the #minecraft:logs_that_burn tag, which is the same tag given to TFC logs to allow them to be used in coke/pyrolyse ovens.

## Outcome
Stick bundles could be used in TFC charcoal pits to make charcoal, so this allows the coke oven to fully replace TFC charcoal pits.

## Potential Compatibility Issues
The #minecraft:logs_that_burn tag appears to confer various other tags, including the #minecraft:logs tag. This allows the stick bundle to be used in crafting recipes that require #minecraft:logs, namely some create recipes and macerating into wooden pulp/lathing into long wooden sticks. None of these recipes allow for duplication exploits, and the pulp/long wooden sticks can be created from the constituent sticks already (at a better ratio than using the log).
An alternate solution is to add a creosote/pyrolyse oven recipe specifically for stick bundles instead of giving the tag.