### PR TITLE
Allows all colors of glass to be macerated/hammered to dust

### DIFF
--- a/kubejs/server_scripts/create_connected/tags.js
+++ b/kubejs/server_scripts/create_connected/tags.js
@@ -1,0 +1,7 @@
+const registerCreateConnectedItemTags = (event) => {
+    // Removes tags from the Cherry and Bamboo wooden panes added by Create Connected
+    event.removeAllTagsFrom("create_connected:cherry_window_pane")
+    event.add("c:hidden_from_recipe_viewers", "create_connected:cherry_window_pane")
+    event.removeAllTagsFrom("create_connected:bamboo_window_pane")
+    event.add("c:hidden_from_recipe_viewers", "create_connected:bamboo_window_pane")
+}

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1799,4 +1799,30 @@ const registerGTCEURecipes = (event) => {
 	event.replaceInput({id: 'gtceu:create_mixer/blue_steel'}, 'gtceu:brass_dust', 'gtceu:bismuth_bronze_dust')
 	
 	// #endregion
+
+    // #region Add all glass colors to macerator/hammer
+    event.remove({id: "gtceu:macerator/macerate_glass"});
+    event.recipes.gtceu.macerator("gtceu:macerator/macerate_glass")
+        .itemInputs(
+            "#forge:glass"
+        )
+        .itemOutputs("gtceu:glass_dust")
+        .duration(20)
+        .EUt(2);
+
+    event.remove({id: "gtceu:macerator/macerate_glass_pane"});
+    event.recipes.gtceu.macerator("gtceu:macerator/macerate_glass_pane")
+        .itemInputs(
+            "#forge:glass_panes"
+        )
+        .itemOutputs("3x gtceu:tiny_glass_dust")
+        .duration(6)
+        .EUt(2)
+
+    event.replaceInput(
+        {id: "gtceu:shaped/glass_dust_hammer"},
+        "minecraft:glass",
+        "#forge:glass"
+    );
+    // #endregion
 }

--- a/kubejs/server_scripts/main_server_script.js
+++ b/kubejs/server_scripts/main_server_script.js
@@ -10,6 +10,7 @@ ServerEvents.tags('item', event => {
     registerComputerCraftItemTags(event)
     registerCreateItemTags(event)
     registerCreateAdditionsItemTags(event)
+    registerCreateConnectedItemTags(event)
     registerExtendedAE2ItemTags(event)
     registerFirmaCivItemTags(event)
     registerFirmaLifeItemTags(event)


### PR DESCRIPTION
## What is the new behavior?
All colors of glass (and tinted glass as well) can now be macerated in the macerator or hammered in the crafting window to dust. Colored glass panes work as well.

## Implementation Details
The default maceration recipes for glass and glass panes were removed and replaced with #forge:glass and #forge:glass_panes.

## Outcome
Most TFC sands by default output colored glass, while previously only clear glass could provide glass dust (needed for vacuum tubes). This means you had to go out searching for white sand for silica batches to progress into LV. Allowing colored glasses allows all sand types to be used for glass dust.

## Additional Information
The Create bamboo and cherry glass panes are tagged with #forge:glass_panes, so show up in the list of possible inputs for tiny glass dust. However, these items are hidden from EMI and have no recipes, so they're not intended inputs. A possible fix is to remove #forge:glass_panes from these blocks?