### PR TITLE
Add alternate papermaking quests using treated hide

### DIFF
--- a/config/ftbquests/quests/chapters/primitive_age.snbt
+++ b/config/ftbquests/quests/chapters/primitive_age.snbt
@@ -3782,7 +3782,11 @@
 			y: 3.0d
 		}
 		{
-			dependencies: ["7E8F9F6F35614B13"]
+			dependencies: [
+				"7E8F9F6F35614B13"
+				"25C1C646790CFB6E"
+			]
+			dependency_requirement: "one_completed"
 			id: "2658E7679CD42ACD"
 			tasks: [{
 				id: "5D95FC92B930ACC0"
@@ -5227,6 +5231,32 @@
 			}]
 			x: 24.5d
 			y: 24.0d
+		}
+		{
+			dependencies: [
+				"0988DE53C9217CE6"
+				"332C0086D53DDAA3"
+			]
+			id: "25C1C646790CFB6E"
+			tasks: [{
+				id: "7ACE2BE9075B650E"
+				item: "tfc:treated_hide"
+				type: "item"
+			}]
+			x: 24.5d
+			y: -7.0d
+		}
+		{
+			dependencies: ["76EF4D00586A8B74"]
+			hide_dependency_lines: true
+			id: "332C0086D53DDAA3"
+			tasks: [{
+				id: "322DF9A30CFE57CE"
+				item: "tfc:groundcover/pumice"
+				type: "item"
+			}]
+			x: 27.0d
+			y: -7.0d
 		}
 	]
 	title: "Primitive Age"


### PR DESCRIPTION
## What is the new behavior?
Adds 2 new quests related to making paper through treated hide. Also changed the paper quest to require only one of either treated hide or unrefined paper.

## Outcome
Previously, the paper quest was only completed through the papyrus chain. This meant that it wouldn't be completed if you used treated hide to make paper. Since the paper quest is a prereq for the entire LV quest chain through resistors, you were essentially locked out of those quests unless you went through the papyrus chain. Now, you can complete the paper quest using treated hide. 

## Additional Information
![image](https://github.com/user-attachments/assets/866339f0-f2a2-4602-9424-f3c045a12659)