### PR TITLE
create fluxstone recipes in macerator and forge hammer

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -50,6 +50,18 @@ const registerGTCEURecipes = (event) => {
 
     //#endregion
 
+    event.recipes.gtceu.macerator('flux')
+        .itemInputs('#tfc:fluxstone')
+        .itemOutputs('2x tfc:powder/flux')
+        .duration(30)
+        .EUt(2)
+
+    event.recipes.gtceu.forge_hammer('flux')
+        .itemInputs('#tfc:fluxstone')
+        .itemOutputs('2x tfc:powder/flux')
+        .duration(30)
+        .EUt(2)
+
     //#region Выход: Диоксид силикона
 
     event.recipes.gtceu.electrolyzer('sand_electrolysis')             


### PR DESCRIPTION
## What is the new behavior?
creates a flux recipe for the macerator and forge hammer, to live alongside the quern and manual hammer recipes.

## Additional Information
this recipe may not be incredibly necessary, but it may fill out some area in the Steam Age, and also follows the intuitive idea that anything you can do in the quern you can do in the macerator. the forge hammer recipe was also added as you can craft it with a hammer. the actual recipe duration is up for debate i suppose, but i picked something moderately reasonable: quite a bit faster than the quern, but not nearly instant.

## Potential Compatibility Issues
N/A