### PR TITLE
Hanging Sign Metal Dupe fix

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1891,4 +1891,40 @@ const registerGTCEURecipes = (event) => {
         .EUt(96)
         .circuit(2)
     // #endregion
+
+    // #region Fix TFC hanging sign metal dupe for Macerator and Arc Furnace
+
+    const SIGN_METALS = [
+		"copper",
+		"bronze",
+		"black_bronze",
+		"bismuth_bronze",
+		"wrought_iron",
+		"steel",
+		"black_steel",
+		"red_steel",
+		"blue_steel"
+	];
+	
+    SIGN_METALS.forEach(metal => {
+        global.TFC_WOOD_TYPES.forEach(wood => {
+            event.remove(`gtceu:macerator/macerate_wood/hanging_sign/${metal}/${wood}`)
+            event.recipes.gtceu.macerator(`gtceu:macerator/macerate_wood/hanging_sign/${metal}/${wood}`)
+                .itemInputs(`tfc:wood/hanging_sign/${metal}/${wood}`)
+                .itemOutputs('gtceu:wood_dust')
+                .chancedOutput(`gtceu:tiny_${metal}_dust`, 3750, 0)
+                .duration(108)
+                .EUt(8)
+
+            event.remove(`gtceu:arc_furnace/arc_wood/hanging_sign/${metal}/${wood}`)
+            event.recipes.gtceu.arc_furnace(`gtceu:arc_furnace/macerate_wood/hanging_sign/${metal}/${wood}`)
+                .itemInputs(`tfc:wood/hanging_sign/${metal}/${wood}`)
+                .itemOutputs('gtceu:tiny_ash_dust')
+                .chancedOutput(`gtceu:${metal}_nugget`, 3750, 0)
+                .inputFluids(Fluid.of('gtceu:oxygen', 12))
+                .duration(12)
+                .EUt(30)
+        })
+    })
+    // #endregion
 }


### PR DESCRIPTION
## What is the new behavior?
Fixes the TFC Hanging Signs exploit that allowed users to input 2 ingots worth of metal into making them and then getting 3 ingots worth of metal back by using either an Arc Furnace or Macerator. This was due to the hanging signs being made in such a large quantity by cheap ingredients that the lowest possible output granularity (tiny dusts/nuggets) were too large to capture the material put into their manufacture.

Recipe for Macerating black steel acacia hanging signs before this change:
![2025-01-19_08 10 28](https://github.com/user-attachments/assets/ed9b5324-654a-40f7-a228-d70bf69de929)

Recipe after this change:
![2025-01-19_08 16 17](https://github.com/user-attachments/assets/ac4c05ea-6376-44b0-ba46-6aa7d7fb604f)

Since adding even more granularity didn't make much sense, I just made the recipe outputs for hanging sign recycling with the Macerator & Arc furnace, which originally gave 1 full nugget's worth (16mB) of metals back, to give the 16mB only 37.5% of the time.
This should roughly equal to, over time, ~6mB per hanging sign, which is equal to the metal input when crafting them
(9mB per chain x2 -> 3 Hanging Signs = 6mB per sign)

## Implementation Details
Although this leaves the output fully to chance and doesn't make sense if you DO get the metal back since, well, it's more than double what you put in to make it in the first place, I think it can be explained as the chains being too small and delicate to be properly salvaged through such a destructive process.

## Outcome
Fixes #679.

## Additional Information

Alternatives considered:
- implement a new item that's of even more granularity than tiny piles/nuggets, 1/16 of an ingot. Obviously this would be overscoping the fix
- making the output not give metals back at all.
- arguing for some other balancing so the most granular amount of metal is always a nugget. Also overscope and not really fit for this sort of quick fix

## Potential Compatibility Issues
This recipe is from GTCEU apparently, and no other kubejs script touches it to my knowledge.