### PR TITLE
Fix collapsible brick slab blocks

### DIFF
--- a/kubejs/server_scripts/tfc/tags.js
+++ b/kubejs/server_scripts/tfc/tags.js
@@ -192,6 +192,15 @@ const registerTFCItemTags = (event) => {
             event.add(`tfg:rock_walls`, `tfc:rock/${slabType}/${stoneTypeName}_wall`)
         })
     })
+    
+    // Теги для кирпичных ступенек тфк
+    global.TFC_STONE_TYPES.forEach(stoneTypeName => {
+        global.TFC_BRICK_SLAB_BLOCK_TYPES.forEach(slabType => {
+            event.add(`tfg:brick_slabs`, `tfc:rock/${slabType}/${stoneTypeName}_slab`)
+            event.add(`tfg:brick_stairs`, `tfc:rock/${slabType}/${stoneTypeName}_stairs`)
+            event.add(`tfg:brick_walls`, `tfc:rock/${slabType}/${stoneTypeName}_wall`)
+        })
+    })
 
     // Удаление тегов у отключенных предметов
     global.TFC_DISABLED_ITEMS.forEach(item => {
@@ -210,6 +219,15 @@ const registerTFCBlockTags = (event) => {
             event.add(`tfg:rock_slabs`, `tfc:rock/${slabType}/${stoneTypeName}_slab`)
             event.add(`tfg:rock_stairs`, `tfc:rock/${slabType}/${stoneTypeName}_stairs`)
             event.add(`tfg:rock_walls`, `tfc:rock/${slabType}/${stoneTypeName}_wall`)
+        })
+    })
+    
+    // Теги для кирпичных ступенек тфк
+    global.TFC_STONE_TYPES.forEach(stoneTypeName => {
+        global.TFC_BRICK_SLAB_BLOCK_TYPES.forEach(slabType => {
+            event.add(`tfg:brick_slabs`, `tfc:rock/${slabType}/${stoneTypeName}_slab`)
+            event.add(`tfg:brick_stairs`, `tfc:rock/${slabType}/${stoneTypeName}_stairs`)
+            event.add(`tfg:brick_walls`, `tfc:rock/${slabType}/${stoneTypeName}_wall`)
         })
     })
 

--- a/kubejs/startup_scripts/tfc/constants.js
+++ b/kubejs/startup_scripts/tfc/constants.js
@@ -757,17 +757,23 @@ global.TFC_WOOD_ITEM_TYPES_TO_WOOD_DUST = {
 };
 
 /**
- * Хранит названия типов полублоков из камня в TFC.
+ * Хранит названия типов полублоков из камня в TFC. (Не кирпичей)
  */
 global.TFC_ROCK_SLAB_BLOCK_TYPES = [
     'raw',
     'smooth',
-    'bricks',
     'cobble',
-    'mossy_bricks',
     'mossy_cobble',
-    'cracked_bricks'
 ];
+
+/**
+ * Хранит названия типов полублоков из кирпича из камня в TFC
+ */
+global.TFC_BRICK_SLAB_BLOCK_TYPES = [
+    'bricks',
+    'mossy_bricks',
+    'cracked_bricks'
+]
 
 /**
  * Хранит названия цветов песка в TFC.


### PR DESCRIPTION
## What is the new behavior?
This PR fixes collapsible bricks. Bricks are supposed to be sturdier than raw/smooth rock blocks. But even if bricks are not collapsible, brick slab blocks are for some reason. And because they can be used for decoration, it can bring a lot of pain.

## Outcome
Brick slab blocks don't collapse

## Potential Compatibility Issues
Constant `global.TFC_ROCK_SLAB_BLOCK_TYPES` and tags `tfg:rock_slabs`, `tfg:rock_stairs`, `tfg:rock_walls` got changed contents. But search showed no other usage for them besides in the changed file in the code section for collapsible stuff, so it must be okay.