### PR TITLE
Add seaweed and kelp drying recipes

### DIFF
--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -113,6 +113,11 @@ const registerTFCHeats = (event) => {
 
     // Ведро из красной
     event.itemHeat('tfc:metal/bucket/red_steel', 1.429, 924, 1232)
+
+    // Seaweed and Kelp
+    event.itemHeat('tfc:groundcover/seaweed', 1.0, null, null)
+    event.itemHeat('tfc:plant/leafy_kelp', 1.0, null, null)
+    event.itemHeat('tfc:plant/winged_kelp', 1.0, null, null)
 }
 
 const registerTFCFuels = (event) => {

--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -3463,6 +3463,14 @@ const registerTFCRecipes = (event) => {
     // Jute Fiber
     generateMixerRecipe(event, 'tfc:jute', Fluid.of('minecraft:water', 200), 'tfc:jute_fiber', null, [], 100, 4, 16, 'tfg:tfc/jute_fiber')
 
+    // Seaweed and kelp
+    event.recipes.tfc.heating('tfc:groundcover/seaweed', 200)
+	.resultItem('tfc:food/dried_seaweed')
+    event.recipes.tfc.heating('tfc:plant/leafy_kelp', 200)
+	.resultItem('tfc:food/dried_kelp')
+    event.recipes.tfc.heating('tfc:plant/winged_kelp', 200)
+	.resultItem('tfc:food/dried_kelp')
+	
     // Soda Ash
     event.smelting('3x tfc:powder/soda_ash', 'tfc:food/dried_seaweed').id('tfg:smelting/dried_seaweed_to_soda')
     event.smelting('3x tfc:powder/soda_ash', 'tfc:food/dried_kelp').id('tfg:smelting/dried_kelp_to_soda')


### PR DESCRIPTION
## What is the new behavior?
Adds drying recipes to seaweed and kelp, just like fresh seaweed and giant kelp flowers have currently.
They are set to 200 temperature, which is the same defined for the recipes in tfc:
https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.21.x/src/generated/resources/data/tfc/recipe/heating/food/dried_seaweed.json
And their corresponding item heat capacity is set to 1.0, just like the existing seaweed/kelp recipes.

This is related to this issue: https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/464

## Implementation Details
Maybe instead of hardcoding the recipes a tag system could be added to the seaweeds and kelps, but alas this is my first time working with kubejs and I have no idea how to set that up. If there is no big push for it, this should cover most bases.

## Outcome
Recipes to dry kelp and seaweed are added.
Fixes: #464 

## Potential Compatibility Issues
We're not using tags, so other seaweed recipes like the plantball are missing. These recipes also turn non-edible items into edible ones, which can be a bit exploity since non-edible items don't rot.