### PR TITLE
Create Deco and Railways: Locometal Integration Scripts

### DIFF
--- a/kubejs/server_scripts/create_deco/recipes.js
+++ b/kubejs/server_scripts/create_deco/recipes.js
@@ -1,0 +1,108 @@
+const replaceMe = {
+	'#createdeco:internal/plates/andesite_plates': 'gtceu:wrought_iron_plate',
+	'#createdeco:internal/plates/copper_plates': 'gtceu:copper_plate',
+	'createdeco:zinc_sheet': 'gtceu:zinc_plate',
+	'#createdeco:internal/plates/brass_plates': 'gtceu:brass_plate',
+	'#createdeco:internal/plates/iron_plates': 'gtceu:iron_plate',
+	'createdeco:andesite_bars': 'tfc:metal/bars/wrought_iron',
+	'#createdeco:internal/ingots/copper_ingots': 'gtceu:copper_ingot',
+	'create:zinc_ingot': 'gtceu:zinc_ingot',
+	'#createdeco:internal/ingots/brass_ingots': 'gtceu:brass_ingot',
+	'#createdeco:internal/ingots/iron_ingots': 'gtceu:iron_ingot',
+	'create:andesite_alloy': 'gtceu:wrought_iron_ingot',
+	'#createdeco:internal/ingots/andesite_ingots': 'gtceu:wrought_iron_ingot',
+	'#createdeco:internal/blocks/andesite_blocks': 'tfc:rock/raw/andesite',
+	'#createdeco:internal/blocks/andesite_blocks': 'gtceu:brass_block',
+	'#createdeco:internal/blocks/andesite_blocks': 'tfc:rock/raw/andesite',
+	'minecraft:vine': '#tfc:plants'
+}
+
+const decoBrickColors = {
+	'createdeco:dusk_bricks': 'black',
+	'createdeco:dean_bricks': 'orange',
+	'createdeco:blue_bricks': 'blue',
+	'createdeco:scarlet_bricks': 'red',
+	'createdeco:verdant_bricks': 'green',
+	'createdeco:umber_bricks': 'brown'
+}
+
+const decoLamps = {
+	andesite: 'gtceu:wrought_iron_ingot',
+	copper: 'minecraft:copper_ingot',
+	zinc: 'gtceu:zinc_ingot',
+	brass: 'gtceu:brass_ingot',
+	industrial_iron: 'createdeco:industrial_iron_ingot',
+	iron: 'minecraft:iron_ingot'
+}
+
+const decoLampColors = ['yellow', 'red', 'green', 'blue']
+
+const createDecoIntegration = (event) => {
+	event.remove({type: 'create:compacting', output: 'createdeco:industrial_iron_ingot'})
+	event.recipes.create.filling('2x createdeco:industrial_iron_ingot', [Fluid.of('gtceu:iron', 144), 'minecraft:iron_ingot']).id(`gpedia:industrial_iron/spout`)
+	event.recipes.gtceu.fluid_solidifier(`gpedia:industrial_iron/fluid_solidifier`)
+		.itemInputs(`minecraft:iron_ingot`)
+		.inputFluids(Fluid.of(`gtceu:iron`, 144))
+		.itemOutputs(`2x createdeco:industrial_iron_ingot`)
+		.EUt(24)
+		.duration(20)
+	
+	Object.keys(replaceMe).forEach(replacement => {
+		event.replaceInput({ mod: 'createdeco' }, replacement, replaceMe[`${replacement}`])
+	})
+	
+	Object.keys(decoBrickColors).forEach(bricks => {
+		event.remove({ output: `${bricks}`})
+		event.recipes.tfc.barrel_sealed(100)
+			.outputItem(Item.of(`${bricks}`))
+			.inputItem(Item.of('minecraft:bricks'))
+			.inputFluid(TFC.fluidStackIngredient(`tfc:${decoBrickColors[`${bricks}`]}_dye`, 144))
+			.id(`gpedia:createdeco/brick_color_${decoBrickColors[`${bricks}`]}`)
+		event.recipes.gtceu.chemical_bath(`gpedia:createdeco/chemical_bath/brick_color_${decoBrickColors[`${bricks}`]}`)
+			.itemOutputs(Item.of(`${bricks}`))
+			.itemInputs(Item.of('minecraft:bricks'))
+			.inputFluids(Fluid.of(`gtceu:${decoBrickColors[`${bricks}`]}_dye`, 18))
+			.EUt(24)
+			.duration(20)
+	})
+
+	event.recipes.tfc.barrel_sealed(100)
+		.outputItem(Item.of('createdeco:pearl_bricks'))
+		.inputItem(Item.of('minecraft:bricks'))
+		.inputFluid(TFC.fluidStackIngredient('tfc:lye', 144))
+		.id('gpedia:createdeco/brick_color_white')
+
+	event.recipes.gtceu.chemical_bath('gpedia:createdeco/chemical_bath/brick_color_white')
+		.itemOutputs(Item.of('createdeco:pearl_bricks'))
+		.itemInputs(Item.of('minecraft:bricks'))
+		.inputFluids(Fluid.of('gtceu:chlorine', 18))
+		.EUt(24)
+		.duration(20)
+	
+	decoLampColors.forEach(color => {
+		Object.keys(decoLamps).forEach(mat => {
+			event.remove({ output: `createdeco:${color}_${mat}_lamp` })
+			event.shaped(
+				Item.of(`createdeco:${color}_${mat}_lamp`, 1),
+				[
+					'M  ',
+					'GD ',
+					'M  '
+				],
+				{
+					M: `${decoLamps[`${mat}`]}`,
+					G: `minecraft:glowstone_dust`,
+					D: `#c:${color}_dyes`
+				}
+			)
+		})
+	})
+	
+	/* global.MINECRAFT_DYE_NAMES.forEach(dye => {
+		event.
+	}) */
+}
+
+ServerEvents.recipes( event => {
+	createDecoIntegration(event)
+})

--- a/kubejs/server_scripts/railways/gpedia_locometal_integration.js
+++ b/kubejs/server_scripts/railways/gpedia_locometal_integration.js
@@ -1,0 +1,101 @@
+const locometalDyeGroups = {
+	slashed_locometal: '#railways:palettes/dye_groups/slashed',
+	riveted_locometal: '#railways:palettes/dye_groups/riveted',
+	locometal_pillar: '#railways:palettes/dye_groups/pillar',
+	locometal_smokebox: '#railways:palettes/dye_groups/smokebox',
+	plated_locometal: '#railways:palettes/dye_groups/plated',
+	flat_slashed_locometal: '#railways:palettes/dye_groups/flat_slashed',
+	flat_riveted_locometal: '#railways:palettes/dye_groups/flat_riveted'
+}
+
+const locometalBase = {
+	slashed_locometal: 'slashed_locometal',
+	riveted_locometal: 'riveted_locometal',
+	locometal_pillar: 'locometal_pillar',
+	locometal_smokebox: 'locometal_smokebox',
+	plated_locometal: 'plated_locometal',
+	flat_slashed_locometal: 'flat_slashed_locometal',
+	flat_riveted_locometal: 'flat_riveted_locometal'
+}
+
+const railwaysLocometalIntegration = (event) => {
+	for(var locometal in locometalBase) {
+		event.recipes.create.cutting(`8x railways:${locometal}`, 'minecraft:iron_block').processingTime(200);
+		event.recipes.create.cutting(`16x railways:${locometal}`, 'gtceu:wrought_iron_block').processingTime(200);
+		event.recipes.create.cutting(`24x railways:${locometal}`, 'gtceu:steel_block').processingTime(200);
+		event.recipes.create.cutting(`railways:${locometal}`, `#railways:palettes/cycle_groups/base`).processingTime(20);
+		event.recipes.gtceu.chemical_bath(`gpedia:undying/locometal/${locometal}`)
+				.itemInputs(Item.of(locometalDyeGroups[`${locometal}`], 1))
+				.inputFluids(Fluid.of(`gtceu:chlorine`, 18))
+				.itemOutputs(Item.of(`railways:${locometal}`))
+				.duration(20)
+				.EUt(24)
+	}
+	
+	event.recipes.create.item_application(`railways:iron_wrapped_locometal`, [`#railways:palettes/cycle_groups/base`,'gtceu:wrought_iron_plate']);
+	event.recipes.create.item_application(`railways:copper_wrapped_locometal`, [`#railways:palettes/cycle_groups/base`,'gtceu:copper_plate']);
+	event.recipes.create.item_application(`railways:brass_wrapped_locometal`, [`#railways:palettes/cycle_groups/base`,'gtceu:brass_plate'])
+	
+	event.recipes.gtceu.chemical_bath(`gpedia:undying/brass_wrapped_locometal`)
+			.itemInputs('#railways:palettes/dye_groups/brass_wrapped_slashed')
+			.inputFluids(Fluid.of(`gtceu:chlorine`, 18))
+			.itemOutputs(`railways:brass_wrapped_locometal`)
+			.duration(20)
+			.EUt(24);
+		event.recipes.gtceu.chemical_bath(`gpedia:undying/copper_wrapped_locometal`)
+			.itemInputs('#railways:palettes/dye_groups/copper_wrapped_slashed')
+			.inputFluids(Fluid.of(`gtceu:chlorine`, 18))
+			.itemOutputs(`railways:copper_wrapped_locometal`)
+			.duration(20)
+			.EUt(24);
+		event.recipes.gtceu.chemical_bath(`gpedia:undying/iron_wrapped_locometal`)
+			.itemInputs('#railways:palettes/dye_groups/iron_wrapped_slashed')
+			.inputFluids(Fluid.of(`gtceu:chlorine`, 18))
+			.itemOutputs(`railways:iron_wrapped_locometal`)
+			.duration(20)
+			.EUt(24)
+
+	global.MINECRAFT_DYE_NAMES.forEach(dye => {
+		for(var locometal in locometalBase) {
+			event.recipes.gtceu.chemical_bath(`gpedia:chemical_dying_locometal/${locometal}/${dye}`)
+				.itemInputs(Item.of(locometalDyeGroups[`${locometal}`], 1))
+				.inputFluids(Fluid.of(`gtceu:${dye}_dye`, 18))
+				.itemOutputs(Item.of(`railways:${dye}_${locometal}`))
+				.duration(20)
+				.EUt(24);
+			event.shapeless(
+				Item.of(`railways:${dye}_${locometal}`, 8),
+				[
+					Item.of(locometalDyeGroups[`${locometal}`], 8),
+					`1x #forge:dyes/${dye}_dye`
+				]
+			)
+		};
+		event.recipes.create.item_application(`railways:${dye}_iron_wrapped_locometal`, [`#railways:palettes/cycle_groups/${dye}`, 'gtceu:wrought_iron_plate']);
+		event.recipes.create.item_application(`railways:${dye}_copper_wrapped_locometal`, [`#railways:palettes/cycle_groups/${dye}`, 'gtceu:copper_plate']);
+		event.recipes.create.item_application(`railways:${dye}_brass_wrapped_locometal`, [`#railways:palettes/cycle_groups/${dye}`, 'gtceu:brass_plate']);
+		event.recipes.gtceu.chemical_bath(`gpedia:brass_locometal_bathing/${dye}`)
+			.itemInputs('#railways:palettes/dye_groups/brass_wrapped_slashed')
+			.inputFluids(Fluid.of(`gtceu:${dye}_dye`, 18))
+			.itemOutputs(`railways:${dye}_brass_wrapped_locometal`)
+			.duration(20)
+			.EUt(24);
+		event.recipes.gtceu.chemical_bath(`gpedia:copper_locometal_bathing/${dye}`)
+			.itemInputs('#railways:palettes/dye_groups/copper_wrapped_slashed')
+			.inputFluids(Fluid.of(`gtceu:${dye}_dye`, 18))
+			.itemOutputs(`railways:${dye}_copper_wrapped_locometal`)
+			.duration(20)
+			.EUt(24);
+		event.recipes.gtceu.chemical_bath(`gpedia:locometal_bathing/${dye}`)
+			.itemInputs('#railways:palettes/dye_groups/iron_wrapped_slashed')
+			.inputFluids(Fluid.of(`gtceu:${dye}_dye`, 18))
+			.itemOutputs(`railways:${dye}_iron_wrapped_locometal`)
+			.duration(20)
+			.EUt(24);
+	})
+	
+}
+
+ServerEvents.recipes( event => {
+	railwaysLocometalIntegration(event)
+})


### PR DESCRIPTION
## What is the new behavior?
Adds integration scripts for Create: Deco decorative blocks and Create:Steam and Rails Locometal

## Implementation Details
Create: Deco recipes should be checked for difficulty, and server events for both might benefit from being integrated into the main sever event file.

## Outcome
Adds recipes for decorative blocks and colored lights from Create: Deco and Locometal Blocks from Create: Steam and Rails