### PR TITLE
Changed LV casing/hull recipes (again)

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1282,16 +1282,32 @@ const registerGTCEURecipes = (event) => {
 
     //#endregion
 
-    //#region remove LV casing exploit
+    //#region LV casings and hulls
 	
-  event.remove({ id: 'gtceu:assembler/casing_lv' })
+	event.replaceInput('gtceu:shaped/casing_lv', '#forge:plates/red_steel', '#forge:plates/steel')
+	event.replaceInput('gtceu:shaped/casing_lv', '#forge:plates/blue_steel', '#forge:plates/steel')
+	event.replaceInput('gtceu:shaped/lv_machine_hull', '#forge:plates/wrought_iron', '#forge:plates/red_steel')
+		
+    // Replace red steel outputs with 8x steel, delete blue steel outputs.
+    event.replaceOutput(
+        [/gtceu:arc_furnace\/arc_lv_.*/, 'gtceu:arc_furnace/arc_maintenance_hatch'],
+        '#forge:ingots/red_steel', '8x #forge:ingots/steel')
 
-	event.recipes.gtceu.assembler('tfg:assembler/casing_lv')
-		.itemInputs('4x gtceu:blue_steel_plate', '4x gtceu:red_steel_plate')
-		.itemOutputs('gtceu:lv_machine_casing')
-		.circuit(8)
-		.duration(50)
-		.EUt(16)
+    event.replaceOutput(
+        [/gtceu:arc_furnace\/arc_lv_.*/, 'gtceu:arc_furnace/arc_maintenance_hatch'],
+        '#forge:ingots/blue_steel', '')
+
+    event.replaceOutput(
+        [/gtceu:macerator\/macerate_lv_.*/, 'gtceu:macerator/macerate_maintenance_hatch'],
+        '#forge:dusts/red_steel', '8x #forge:dusts/steel')
+
+    event.replaceOutput(
+        [/gtceu:macerator\/macerate_lv_.*/, 'gtceu:macerator/macerate_maintenance_hatch'],
+        '#forge:dusts/blue_steel', '')
+		
+	event.replaceOutput(
+		['gtceu:arc_furnace/arc_configurable_maintenance_hatch', 'gtceu:arc_furnace/arc_auto_maintenance_hatch'],
+		['#forge:ingots/blue_steel', '#forge:ingots/red_steel'], '8x #forge:ingots/steel')
 		
 	//#endregion
 		


### PR DESCRIPTION
## What is the new behavior?
LV casings are now always 8 steel plates, both in a crafting grid and in an assembler. Everything LV arc furnaces/macerates down into 8 steel ingots/dust.
LV hulls now require 2 red steel plates instead of 2 wrought iron plates.
MV is unchanged, and then polyethylene can be used to make casings without the red steel.

## Implementation Details
I used the temporary code from 0.7.16 that @/fluffle wrote.

## Outcome
The colored steel is still required, but it's not nearly as annoying as before. Blue steel is popular for tools and lamps so people will want to make a bunch of that anyway.
I liked that people were automating their TFC blast furnace before because of how much steel they needed.

## Additional Information
The all colored steel change in 0.7.17 is very unpopular and some people aren't updating to the latest version because of this change. I think this new change is a fair compromise.