### PR TITLE
Add glowstone as infinite lamp fuel

### DIFF
--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -126,6 +126,7 @@ const registerTFCFuels = (event) => {
 
 const registerTFCLampFuels = (event) => {
     event.lampFuel('gtceu:creosote', '#tfc:lamps', 1000)
+    event.lampFuel("gtceu:glowstone", "#tfc:lamps", -1)
 }
 
 const registerTFCFertilizers = (event) => {


### PR DESCRIPTION
## What is the new behavior?
Adds glowstone as a TFC lamp fuel, it is usable in all types of lamps and burns forever, like lava. The upside is that it is not restricted to blue steel lamps, so you can use other TFC lamps for aesthetics.

## Implementation Details
Added gtceu:glowstone as a lamp fuel with a consumption rate of -1. This is identical to how lava in blue steel lamps works in the TFC code.

## Outcome
This allows TFC lamps (besides blue steel) to be a viable source of infinite light. They are aesthetically pleasing, so it is nice to keep them as an option. To me, it is balanced to allow it in all lamps, not just colored steels, since lava is infinite and glowstone is far harder to produce, offsetting the lower cost of allowing cheaper lamps such as bronze.

## Additional Information
![image](https://github.com/user-attachments/assets/9c71c628-2ddc-46b9-b320-7650a6d03742)