### PR TITLE
Automatic Scraping with Sequenced Assembly

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1331,6 +1331,17 @@ const registerCreateRecipes = (event) => {
 			.duration(40)
 			.EUt(20)
 	})
+
+    //Allow automatic scraping by using sequenced assembly
+    event.forEachRecipe({ type: 'tfc:scraping' }, r =>
+    {
+        let originalRecipeIngredient = r.json.get("ingredient").get("item");
+        let output = r.originalRecipeResult;
+
+        event.recipes.createSequencedAssembly([output], originalRecipeIngredient,[
+            event.recipes.createDeploying(originalRecipeIngredient, [originalRecipeIngredient, '#tfc:knives']).keepHeldItem()
+        ]).transitionalItem(originalRecipeIngredient).loops(16)
+    })
 	
 	// #endregion
 }


### PR DESCRIPTION
## What is the new behavior?
This PR adds Automatic Scraping in Mechanical Age via the utilization of Sequenced Assemblies and Deploying a knife.

## Implementation Details
Implementation was made using KubeJS, utilizing a forEachRecipe call and filtering by the ``tfc:scraping`` type, this means that any other recipe added of type scraping will automatically get a Sequenced Assembly Version.

The amount of deployments needed is 16, which is the total amount needed in any scraping recipe in vanilla TFC.

## Outcome
Players can now auto-scrape without having access to the Cutter

## Additional Information
![image](https://github.com/user-attachments/assets/8c8c7c4e-5819-48f4-a183-3bbab4c68e1c)
![image](https://github.com/user-attachments/assets/6cc85a9b-3592-42e5-af47-c2e9ce6c8b9d)


## Potential Compatibility Issues
None AFAIK