### PR TITLE
Adds heat values for items with valid heating recipes but no heat values

### DIFF
--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_tips/blast_furnace_tips.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_tips/blast_furnace_tips.json
@@ -27,12 +27,6 @@
 		},
 		{
 			"type": "patchouli:spotlight",
-			"title": "Valid Inputs",
-			"item": "gtceu:iron_dust",
-			"text": "Only certain processing stages of ores are accepted in the blast furnace. $(thing)Ore Dusts$(), $(thing)Raw Ores$(), and $(thing)Cast/Wrought Iron Ingots$() work, while $(thing)Crushed$(), $(thing)Impure$(), or other stages of processing will not. But you really should $(l:tfc:tfg_ores/ore_basics#processing)Process$() your ores to dust."
-		},
-		{
-			"type": "patchouli:spotlight",
 			"title": "Automation",
 			"item": "create:mechanical_pump",
 			"text": "You'll need lots of $(item)Steel$() for the $(thing)Steam$() and $(thing)LV$() ages. Lots of steel. The $(thing)Electric Blast Furnace$() is far off, so maybe think about optimizing your steel production."

--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -78,6 +78,13 @@ const registerTFCHeats = (event) => {
             makeItemHeatByTagPrefix(TFGTagPrefix.richRawOre, material, tfcProperty, 1.429)
             makeItemHeatByTagPrefix(TFGTagPrefix.poorRawOre, material, tfcProperty, 1.429)
 
+            // Ore processing stages
+            makeItemHeatByTagPrefix(TagPrefix.dustImpure, material, tfcProperty, 1.429)
+            makeItemHeatByTagPrefix(TagPrefix.dustPure, material, tfcProperty, 1.429)
+            makeItemHeatByTagPrefix(TagPrefix.crushed, material, tfcProperty, 1.429)
+            makeItemHeatByTagPrefix(TagPrefix.crushedPurified, material, tfcProperty, 1.429)
+            makeItemHeatByTagPrefix(TagPrefix.crushedRefined, material, tfcProperty, 1.429)
+
             makeItemHeatByTagPrefix(TFGTagPrefix.toolHeadSword, material, tfcProperty, 2.875)
             makeItemHeatByTagPrefix(TFGTagPrefix.toolHeadShovel, material, tfcProperty, 1.429)
             makeItemHeatByTagPrefix(TFGTagPrefix.toolHeadScythe, material, tfcProperty, 1.429)

--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -71,6 +71,8 @@ const registerTFCHeats = (event) => {
             makeItemHeatByTagPrefix(TagPrefix.bolt, material, tfcProperty, 0.245)
             makeItemHeatByTagPrefix(TagPrefix.screw, material, tfcProperty, 0.567)
             makeItemHeatByTagPrefix(TagPrefix.nugget, material, tfcProperty, 0.124)
+            makeItemHeatByTagPrefix(TagPrefix.block, material, tfcProperty, 20)
+            makeItemHeatByTagPrefix(TagPrefix.rodLong, material, tfcProperty, 1.429)
 
             makeItemHeatByTagPrefix(TagPrefix.ingot, material, tfcProperty, 1.429)
             


### PR DESCRIPTION
## What is the new behavior?
Fixes the issue where crushed/processed ores do not heat up and thus can never melt into anything in the crucible/blast furnace. Also removed the page in the blast furnace tips that detailed which inputs would work, since all inputs should now work so the page is now irrelevant.

## Implementation Details
Added item heat values through makeItemHeatByTagPrefix() in tfc/data.js for the various stages of ore processing. This should not have any adverse affects, as far as I can tell, as it should only affect ores.

## Outcome
Now you can melt your purified ores directly into liquid, if you so desire. Although it is incredibly stupid to do so, but to each their own.

## Additional Information
![image](https://github.com/user-attachments/assets/4ecb707a-3464-438c-a9d8-3405afb52e70)