### PR TITLE
Fixed cassiterite heating "exploit"

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -1159,7 +1159,7 @@ const registerTFCRecipes = (event) => {
                 if (!tinyDust.isEmpty()) {
                    
                     event.recipes.tfc.heating(tinyDust, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(16, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(16, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/tiny_dust/${material.getName()}`)
                     
                 }
@@ -1169,7 +1169,7 @@ const registerTFCRecipes = (event) => {
                 if (!smallDust.isEmpty()) {
                    
                     event.recipes.tfc.heating(smallDust, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(36, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(36, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/small_dust/${material.getName()}`)
                     
                 }
@@ -1179,7 +1179,7 @@ const registerTFCRecipes = (event) => {
                 if (!dust.isEmpty()) {
                    
                     event.recipes.tfc.heating(dust, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(144, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(144, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/dust/${material.getName()}`)
                     
                 }
@@ -1189,7 +1189,7 @@ const registerTFCRecipes = (event) => {
                 if (!impureDust.isEmpty()) {
                    
                     event.recipes.tfc.heating(impureDust, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(80, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(80, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/impure_dust/${material.getName()}`)
                     
                 }
@@ -1199,7 +1199,7 @@ const registerTFCRecipes = (event) => {
                 if (!purifiedDust.isEmpty()) {
                    
                     event.recipes.tfc.heating(purifiedDust, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(120, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(120, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/purified_dust/${material.getName()}`)
                     
                 }
@@ -1214,7 +1214,7 @@ const registerTFCRecipes = (event) => {
                 if (!crushedOre.isEmpty()) {
                    
                     event.recipes.tfc.heating(crushedOre, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(80, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(80, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/crushed_ore/${material.getName()}`)
                     
                 }
@@ -1224,7 +1224,7 @@ const registerTFCRecipes = (event) => {
                 if (!crushedPurifiedOre.isEmpty()) {
                    
                     event.recipes.tfc.heating(crushedPurifiedOre, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(100, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(100, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/crushed_purified_ore/${material.getName()}`)
                     
                 }
@@ -1234,7 +1234,7 @@ const registerTFCRecipes = (event) => {
                 if (!crushedRefinedOre.isEmpty()) {
                    
                     event.recipes.tfc.heating(crushedRefinedOre, tfcProperty.getMeltTemp())
-                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetal(110, tfcProperty.getPercentOfMaterial())))
+                        .resultFluid(Fluid.of(outputMaterial.getFluid(), global.calcAmountOfMetalProcessed(110, tfcProperty.getPercentOfMaterial())))
                         .id(`tfg:heating/crushed_refined_ore/${material.getName()}`)
                     
                 }

--- a/kubejs/startup_scripts/tfc/constants.js
+++ b/kubejs/startup_scripts/tfc/constants.js
@@ -1071,3 +1071,10 @@ global.calcAmountOfMetal = (defaultAmount, percents) => {
     const value = defaultAmount / (100 / percents)
     return (value % 2 == 0) ? value : Math.round(value) - 1
 }
+
+// This prevents the "exploit" where Cassiterite dust gives 2x as much from melting as smelting in a furnace
+global.calcAmountOfMetalProcessed = (defaultAmount, percents) => {
+    const percentPerItem = percents / Math.ceil(percents / 100)
+    const value = defaultAmount * (percentPerItem / 100)
+    return (value % 2 == 0) ? value : Math.round(value) - 1
+}


### PR DESCRIPTION
## What is the new behavior?
Cassiterite dust and cassiterite sand dust now correctly melt down to 144 mb and 108 mb respectively of tin. All stages of ore processing have also been edited, making all stages correct proportionally to cassiterite and cassiterite sand's correct richness percentage (100% and 75% respectively).

## Implementation Details
A new function was created in tfc/constants to calculate the yield for "processed" ores. If the percent yield plugged in for a "processed" ore is greater than 100, it calculates the correct percent per item by roughly "estimating" how many output items would be produced by macerating the ore and then dividing the percentage by that. This works correctly for cassiterite and cassiterite sand. 
The only heating recipes that now use the new function are the heating recipes for crushed, purified, and refined ores, dusts and their small/tiny versions, and impure dusts. This means that raw ores are not touched.

An alternate solution would be to have the new calcAmountOfMetalProcessed function cap the percent at 100. This has the benefit of not "breaking" for possible future ores that may need to output more than 2 crushed ore per raw ore and simultaneously have a low yield, but has the drawback of making all ores with a percent yield greater than 100 equivalent, i.e. cassiterite and cassiterite sands would have equal yields when melting down.

Another alternate solution would be to make macerating raw cassiterite/cassiterite sand produce only 1 crushed ore, but make smelting their dusts/all other stages of processing return 2 ingots.

## Outcome
Currently, melting cassiterite/cassiterite sand down in a crucible returns more metal than smelting it in a furnace, since the percent yield system did not correctly account for the fact that cassiterite's yield is doubled on the crushing step, not on the smelting step. Now, melting these ores is in line with how it should work. Additionally, if more ores are added with > 100% richness, this solution should work out of the box for them.

## Additional Information
![image](https://github.com/user-attachments/assets/e422c15a-0357-4e2d-97b2-713ae19ce03b)
![image](https://github.com/user-attachments/assets/80e701a5-d6fb-41a7-883b-65ec7aa91bee)