### PR TITLE
Get small dust from failed pressing

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1477,7 +1477,6 @@ const registerGTCEURecipes = (event) => {
             let plateStack = ChemicalHelper.get(TagPrefix.plate, material, 1)
             let blockStack = ChemicalHelper.get(TagPrefix.block, material, 1)
             let smallDustStack = ChemicalHelper.get(TagPrefix.dustSmall, material, 1)
-            console.log(smallDustStack);
             
 
             let matAmount = TagPrefix.block.getMaterialAmount(material) / GTValues.M;

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1476,15 +1476,21 @@ const registerGTCEURecipes = (event) => {
         {
             let plateStack = ChemicalHelper.get(TagPrefix.plate, material, 1)
             let blockStack = ChemicalHelper.get(TagPrefix.block, material, 1)
+            let smallDustStack = ChemicalHelper.get(TagPrefix.dustSmall, material, 1)
+            console.log(smallDustStack);
+            
 
             let matAmount = TagPrefix.block.getMaterialAmount(material) / GTValues.M;
 
             if (material.hasProperty(PropertyKey.INGOT))
             {
                 if (!plateStack.isEmpty()) {
-                    // Слиток -> Стержень
-                    event.recipes.createPressing(plateStack.withChance(0.8), ingotStack)
-                    .id(`tfg:pressing/${material.getName()}_plate`)
+                    event.recipes.createSequencedAssembly([plateStack.withChance(4), smallDustStack], ingotStack,[
+                        event.recipes.createPressing(ingotStack, ingotStack)
+                    ])
+                    .transitionalItem(ingotStack)
+                    .loops(1)
+                    .id(`tfg:pressing/${material.getName()}_plate`);
 
                     if (!blockStack.isEmpty()) {
                     // 9х Слиток -> Блок


### PR DESCRIPTION
## What is the new behavior?
This PR changes the behaviour of using the mechanical press to get plates. Instead of having a 80% chance of succeed and when failing returning nothing, when it fails, the player is awarded with 1 small dust of the material. This way press is still a gambling method of getting plates but when it fails at least you get something in return (even if you'd need 4 fails to get another attempt)

## Implementation Details
The pressing recipe of create only accepts a % based chance of multiple outputs, this means that adding a small dust to the array of outputs meant that there was a slight chance for the player to end up with 1 plate and 1 small dust, breaking the laws of conservation of matter

To fix this, the recipes for pressing ingots into plates is now a sequenced assembly that only requires 1 press action to get the result. Which has a 80% chance to be the plate, and if the roll fails, you get a small dust

## Outcome
Creating plates with Create pressing is now slightly less infuriating, still can end with an overall loss of materials.

## Additional Information

New recipe using sequenced assembly, random salvage is only small dusts. Plate retains its 80% chance output.

![image](https://github.com/user-attachments/assets/eef675ae-3f2a-4f3f-b558-a46b4f45fc85)

## Potential Compatibility Issues

Other than the cursed aura there doesnt seem to be any issues.