### PR TITLE
Fixes wool cloth recipe conflict

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -3459,6 +3459,7 @@ const registerTFCRecipes = (event) => {
         .itemOutputs('tfc:wool_cloth')
         .duration(100)
         .EUt(4)
+        .circuit(16)
 
     // Jute Fiber
     generateMixerRecipe(event, 'tfc:jute', Fluid.of('minecraft:water', 200), 'tfc:jute_fiber', null, [], 100, 4, 16, 'tfg:tfc/jute_fiber')


### PR DESCRIPTION
## What is the new behavior?
Fixes a recipe conflict for wool cloth in the assembler by adding a circuit to it.

## Outcome
Now wool blocks can be crafted instead of wool cloth in the assembler.

## Additional Information
I haven't personally tested the change yet but @KorGgenT did and it works fine for him.