### PR TITLE
brick - aqueduct circuit swap

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -1852,7 +1852,7 @@ const registerTFCRecipes = (event) => {
         // Кирпич -> Блок кирпичей
         event.recipes.gtceu.assembler(`bricks_${stone}`)             
             .itemInputs(`5x tfc:brick/${stone}`)
-            .circuit(0)
+            .circuit(1)
             .inputFluids(Fluid.of('gtceu:concrete', 72))
             .itemOutputs(`4x tfc:rock/bricks/${stone}`)
             .duration(50)
@@ -1990,7 +1990,7 @@ const registerTFCRecipes = (event) => {
 
         event.recipes.gtceu.assembler(`aqueduct_${stone}`)             
             .itemInputs(`3x tfc:brick/${stone}`)
-            .circuit(1)
+            .circuit(0)
             .inputFluids(Fluid.of('gtceu:concrete', 16))
             .itemOutputs(`tfc:rock/aqueduct/${stone}`)
             .duration(50)


### PR DESCRIPTION
Обоснование: Так как акведуки вряд ли кто то будет крафтить, а кирпичи достаточно распространены, поменял программы местами, тк большинство сборщиков в автокрафтах AE2 стоят с 1 программой, то нужно ставить отдельный с 0, просто чтобы поставить кирпичи на поток.

Justification: Since aqueducts are unlikely to be crafted by anyone, and bricks are quite common, I changed the programs in places, because most assemblers in AE2 autocrafts are with program 1, then you need to put a separate one with 0, just to put the bricks for mass production.

Before:
![image](https://github.com/user-attachments/assets/6daed86b-117f-47ef-a0fc-2d6c81bd1481)

After:
![image](https://github.com/user-attachments/assets/a7ffb0d8-25fd-473e-8ad3-812b746afebb)
