### PR TITLE
create an alternate recipe for soldering alloy

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -31,6 +31,14 @@ const registerGTCEURecipes = (event) => {
 
     //#endregion
 
+    // new soldering alloy: Wood's metal shouldn't be transmutable, so the centrifuge recipe is removed.
+    event.remove('gtceu:centrifuge/decomposition_centrifuging__soldering_alloy')
+    event.recipes.gtceu.mixer('woods_alloy')
+        .itemInputs('15x gtceu:bismuth_dust', '8x gtceu:lead_dust', '4x gtceu:tin_dust', '3x gtceu:cadmium_dust')
+        .itemOutputs('30x gtceu:soldering_alloy_dust')
+        .duration(200)
+        .EUt(30)
+
     //#region Выход: Кварцевый песок
 
     event.shaped('gtceu:quartz_sand_dust', [


### PR DESCRIPTION
## What is the new behavior?
![mixer_woods_alloy](https://github.com/user-attachments/assets/3f619846-2e7f-40f9-a543-67b8e97d97d0)
and the centrifuge recipe for soldering alloy dust has been removed.

## Additional Information
Soldering alloy is the kind of thing that is used well into the endgame, and there are several types of ore that do not currently have any or much use in the game -namely, cadmium and bismuth. I have looked at the wiki page for solder https://en.wikipedia.org/wiki/Solder_alloys
and there are a very wide variety of soldering alloys - which is very much why tin (and in the past, lead) have been used by GT as soldering alloys.

I have attempted to create a new material so the centrifuge recipe could be preserved, but it turns out that kubejs does not allow fluids to have a tag for recipes. this means that every single recipe that uses the other types of solder would need to be updated and not only that, but it would start to severely pollute EMI. Frankly it's probably why GT removed liquid lead.
I've reasoned out that the centrifuge recipe for soldering alloy isn't of much use at all, as solder is almost universally important in the game, and it would just likely be better if there were other ways to turn various things into solder, though that could be a further discussion or a discussion built upon this one. I do believe that givi9ng cadmium a fairly reasonable use (no, batteries are not a reasonable use as they are straight up worse than sodium which is free) will definitely get people to process for it instead of trashing it, and bismuth having a lategame use will definitely round it out as a material. This specific alloy may not be the best solder around, so it could possibly make less, but that is also worthy of discussion in my opinion.