### PR TITLE
Remove graphite to dust macerator recipe

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -2587,6 +2587,16 @@ const registerTFCRecipes = (event) => {
 
     //#endregion
 
+    //#region Graphite recipes
+    global.TFC_QUERN_GRAPHITE_RECIPE_COMPONENTS.forEach(element => {
+        event.recipes.tfc.quern(element.output, element.input)
+            .id(`tfg:quern/${element.name}`)
+
+        event.recipes.createMilling(element.output, element.input)
+            .id(`tfg:milling/${element.name}`)
+    })
+    //#endregion
+
     //#region Рецепты зерен
 
     global.TFC_QUERN_GRAIN_RECIPE_COMPONENTS.forEach(element => {

--- a/kubejs/startup_scripts/tfc/constants.js
+++ b/kubejs/startup_scripts/tfc/constants.js
@@ -999,6 +999,9 @@ global.TFC_QUERN_POWDER_RECIPE_COMPONENTS = [
     { input: '#forge:dusts/borax', output: '4x tfc:powder/flux', name: 'flux_powder' },
     { input: '#forge:dusts/soda_ash', output: '4x tfc:powder/soda_ash', name: 'soda_ash' },
     { input: 'gtceu:charcoal_dust', output: '2x tfc:powder/charcoal', name: 'charcoal' },
+];
+
+global.TFC_QUERN_GRAPHITE_RECIPE_COMPONENTS = [
     { input: 'gtceu:raw_graphite', output: 'gtceu:graphite_dust', name: 'raw_graphite_to_dust' },
     { input: 'gtceu:poor_raw_graphite', output: '5x gtceu:tiny_graphite_dust', name: 'poor_raw_graphite_to_dust' },
     { input: 'gtceu:rich_raw_graphite', output: '2x gtceu:graphite_dust', name: 'rich_graphite_to_dust' },


### PR DESCRIPTION
## What is the new behavior?
Macerating raw graphite ores will now always give crushed ores. Before it would give dust instead which significantly reduced the yield of graphite from ore processing later in the game.

## Implementation Details
Moved the graphite to dust quern recipes to a new global TFC_QUERN_GRAPHITE_RECIPE_COMPONENTS instead of being with TFC_QUERN_POWDER_RECIPE_COMPONENTS and then added to the script code to add each of these recipes to just the quern and millstone.

## Outcome
Fixed issue where macerating raw graphite ores would give dust instead of crushed ore.