### PR TITLE
Update field guide for 0.9

### DIFF
--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
@@ -1,0 +1,86 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Ores, Metal, and Casting",
+  "category": "tfc:getting_started",
+  "icon": "tfc:ore/normal_native_copper",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "In addition to sticks, twigs, and stones on the ground, in your travels you may encounter small pieces of ores scattered around the ground. These are important, as they are one of the only sources of ore and metal before obtaining a pickaxe."
+    },
+    {
+      "type": "patchouli:multiblock",
+      "multiblock": {
+        "pattern": [ [ "    ", "  0 ", "    " ], [ "ABCD", "EFGH", "IJKL" ], [ "XXXX", "XXXX", "XXXX" ] ],
+        "mapping": {
+          "X": "tfc:grass/loam",
+          "A": "tfc:ore/small_native_copper",
+          "B": "tfc:ore/small_native_gold",
+          "C": "tfc:ore/small_hematite",
+          "D": "tfc:ore/small_native_silver",
+          "E": "tfc:ore/small_cassiterite",
+          "F": "tfc:ore/small_bismuthinite",
+          "G": "tfc:ore/small_garnierite",
+          "H": "tfc:ore/small_malachite",
+          "I": "tfc:ore/small_magnetite",
+          "J": "tfc:ore/small_limonite",
+          "K": "tfc:ore/small_sphalerite",
+          "L": "tfc:ore/small_tetrahedrite"
+        }
+      },
+      "name": "",
+      "text": "All small ore pieces",
+      "enable_visualize": false
+    },
+    {
+      "type": "patchouli:text",
+      "text": "These small ore pieces can serve two purposes: they can provide a source of metal, and more importantly, they indicate the presence of a larger vein of ore somewhere nearby, probably underground and close to the surface. Be sure to note where you find small ores, as the location of ore veins will be useful later during $(l:mechanics/prospecting)Prospecting$().$(br2)The twelve types of small ores, and the metal they can be melted into are listed on the next page."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "$(li)Native Copper ($(thing)Copper$())$(li)Native Gold ($(thing)Gold$())$(li)Hematite ($(thing)Cast Iron$())$(li)Native Silver ($(thing)Silver$())$(li)Cassiterite ($(thing)Tin$())$(li)Bismuthinite ($(thing)Bismuth$())$(li)Garnierite ($(thing)Nickel$())$(li)Malachite ($(thing)Copper$())$(li)Magnetite ($(thing)Cast Iron$())$(li)Limonite ($(thing)Cast Iron$())$(li)Sphalerite ($(thing)Zinc$())$(li)Tetrahedrite ($(thing)Copper$())",
+      "title": "Small Ores"
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "casting",
+      "text": "In TerraFirmaCraft, ores each contain a certain number of $(thing)units$(), or $(thing)mB (millibuckets)$() of actual metal which can be extracted. Small ores like this found on the surface are the lowest quality, and only provide $(thing)16 mB$() of metal. In order to extract this metal, it needs to be $(thing)melted$(), and made into tools using a process called $(thing)casting$().",
+      "title": "Casting"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "You will need:$(br)$(li)A $(l:getting_started/pottery#vessel)Small Vessel$()$(li)Enough materials for a $(l:getting_started/pit_kiln)Pit Kiln$().$(li)One or more $(l:getting_started/pottery#mold)Mold(s)$() to cast the molten metal.$(li)And finally, at least 144 mB total of a metal which is suitable for casting: $(thing)Copper$(), in one or more of its three ore forms.$(br2)$(br)$(italic)Note: Casting can also be done with some $(l:getting_started/primitive_alloys)Alloys$()"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "First, open the $(thing)Small Vessel$() and put the ores inside. Count up the total amount of metal in the ores carefully! Then, you need to build a $(l:getting_started/pit_kiln)Pit Kiln$() with the filled small vessel inside. As the vessel heats, the ores inside it will melt, and you'll be left with a vessel of molten metal.$(br2)Take the vessel out and $(item)$(k:key.use)$() while holding it, to open the $(thing)Casting$() interface."
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/gui/casting.png" ],
+      "text": "The Casting Interface.",
+      "border": false
+    },
+    {
+      "type": "patchouli:text",
+      "text": "With the casting interface open, place your empty fired mold in the center slot. It will fill up as long as the vessel remains liquid. (If the vessel solidifies, it can be reheated in another pit kiln.) Once the mold is full, it can be removed and left to cool. Once cool, the mold and its contents can be extracted by using the mold, or putting it in the crafting grid."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "gtceu:shaped/pickaxe_copper",
+      "text": "You are now able to craft your first pickaxe! Find enough copper to make a pickaxe head, fire a pickaxe mold and melt the ore using a pit kiln, then cast a head. Slap it on a stick, and voila!"
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "gtceu:shaped/saw_copper",
+      "text": "The saw allows you turn wood logs into $(l:mechanics/support_beams)support beams$() and lumber, which can further be refined into planks, the crafting bench, and chests. It is also needed to make a $(l:firmaciv/canoe)canoe$()."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfc:crafting/metal/chisel/copper",
+      "text": "The $(l:mechanics/chisel)Chisel$() is useful for working with stone blocks for building and other recipes."
+    }
+  ],
+  "read_by_default": true,
+  "sortnum": 4
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
@@ -68,17 +68,17 @@
     {
       "type": "patchouli:crafting",
       "recipe": "gtceu:shaped/pickaxe_copper",
-      "text": "You are now able to craft your first pickaxe! Find enough copper to make a pickaxe head, fire a pickaxe mold and melt the ore using a pit kiln, then cast a head. Slap it on a stick, and voila!"
+      "text": "You are now able to craft your first pickaxe! Find enough copper to make a pickaxe head, fire a pickaxe mold and melt the ore using a pit kiln, then cast a head. Slap it on a stick, and voila! You can now dig for $(l:tfg_ores/index)ore$()."
     },
     {
-      "type": "patchouli:crafting",
-      "recipe": "gtceu:shaped/saw_copper",
-      "text": "The saw allows you turn wood logs into $(l:mechanics/support_beams)support beams$() and lumber, which can further be refined into planks, the crafting bench, and chests. It is also needed to make a $(l:firmaciv/canoe)canoe$()."
+      "type": "patchouli:spotlight",
+      "item": "tfc:metal/chisel/copper",
+      "text": "A couple other important metal tools are available for progression as well. The $(l:mechanics/chisel)Chisel$() is useful for working with stone blocks for building and other recipes."
     },
     {
-      "type": "patchouli:crafting",
-      "recipe": "tfc:crafting/metal/chisel/copper",
-      "text": "The $(l:mechanics/chisel)Chisel$() is useful for working with stone blocks for building and other recipes."
+      "type": "patchouli:spotlight",
+      "item": "gtceu:copper_saw",
+      "text": "The saw allows you turn wood logs into $(l:mechanics/support_beams)support beams$() and $(thing)lumber$(), which can further be crafted into planks, the crafting bench, barrels, and chests, among other things. It is also useful to make a $(l:firmaciv/canoe)canoe$()."
     }
   ],
   "read_by_default": true,

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/primitive_anvils.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/primitive_anvils.json
@@ -6,16 +6,16 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "An alternative to casting tools directly in the early game, and a requirement for higher tier metals, is to use an $(thing)Anvil$(). An anvil is a block which can be used for two different processes: $(l:mechanics/anvils#working)Working$() and $(l:getting_started/primitive_anvils#welding)Welding$(). An anvil can weld double ingots of the metal type needed to create the next tier anvil above it, which will be necessary to work other items from that metal."
+      "text": "An alternative to casting tools directly in the early game, and a requirement for higher tier metals, is to use an $(thing)Anvil$(). An anvil is a block which can be used for two different processes: $(l:mechanics/anvils#working)working$() and $(l:getting_started/primitive_anvils#welding)welding$(). An anvil can weld double ingots of the metal type needed to create the next tier anvil above it, which will be necessary to work other items from that metal."
     },
     {
       "type": "patchouli:text",
-      "text": "First, you need to acquire a block of $(thing)Raw Rock$(), that is $(thing)Igneous Extrusive$() (Rhyolite, Basalt, Andesite, or Dacite) or $(thing)Igneous Intrusive$() (Granite, Diorite, or Gabbro). You could find and use an exposed block in the world, or you could $(l:getting_started/primitive_anvils#raw_rock)extract one$() from the surrounding rock."
+      "text": "First, you need to acquire a block of $(thing)raw rock$(), that is $(thing)igneous extrusive$() (Rhyolite, Basalt, Andesite, or Dacite) or $(thing)igneous intrusive$() (Granite, Diorite, or Gabbro). You could find and use an exposed block in the world, or you could $(l:getting_started/primitive_anvils#raw_rock)extract one$() from the surrounding rock."
     },
     {
       "type": "patchouli:text",
       "anchor": "stone_anvils",
-      "text": "You will also need any material of $(thing)Hammer$(). In order to make the anvil, simply right click the exposed $(thing)top$() face of one of those raw rock blocks with your $(thing)hammer$(), and voila! An anvil will be formed.$(br2)Anvils have $(l:mechanics/anvils#tiers)tiers$() and the rock anvil is Tier 0 - the lowest tier. It is only able to $(l:getting_started/primitive_anvils#welding)Weld$() Tier I ingots.",
+      "text": "You will also need any material of $(thing)hammer$(). In order to make the anvil, simply right click the exposed $(thing)top$() face of one of those raw rock blocks with your $(thing)hammer$(), and voila! An anvil will be formed.$(br2)Anvils have $(l:mechanics/anvils#tiers)tiers$() and the rock anvil is tier 0 - the lowest tier. It is only able to $(l:getting_started/primitive_anvils#welding)weld$() tier I ingots.",
       "title": "Rock Anvil"
     },
     {
@@ -66,12 +66,12 @@
     {
       "type": "patchouli:text",
       "anchor": "welding",
-      "text": "Welding is a process through which two items are fused together to create a new item. Welding works the same whether on a $(l:getting_started/primitive_anvils)Stone Anvil$() or a $(l:mechanics/anvils)metal anvil$().$(br2)First, you must place the two items you want to weld on the anvil. You can do this either by using the items on the anvil, or by opening the anvil interface and inserting them in the two leftmost slots.",
+      "text": "Welding is a process through which two items are fused together to create a new item. Welding works the same whether on a $(l:getting_started/primitive_anvils)stone anvil$() or a $(l:mechanics/anvils)metal anvil$().$(br2)First, you must place the two items you want to weld on the anvil. You can do this either by using the items on the anvil, or by opening the anvil interface and inserting them in the two leftmost slots.",
       "title": "Welding"
     },
     {
       "type": "patchouli:text",
-      "text": "You also need to have at least one $(l:mechanics/flux)Flux$() in the anvil to aid the welding process. Then, while both items are $(l:mechanics/heating)hot enough$() to weld - the tooltip will say \"Can Weld\" - you must use any $(thing)Hammer$() on the anvil or press the weld button on the anvil interface. You will hear a hammering sound and the items will be welded together."
+      "text": "You also need to have at least one $(l:mechanics/flux)flux$() in the anvil to aid the welding process. Then, while both items are $(l:mechanics/heating)hot enough$() to weld - the tooltip will say \"Can Weld\" - you must use any $(thing)hammer$() on the anvil or press the weld button on the anvil interface. You will hear a hammering sound and the items will be welded together."
     }
   ],
   "read_by_default": true,

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/primitive_anvils.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/primitive_anvils.json
@@ -1,0 +1,88 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Primitive Anvils",
+  "category": "tfc:getting_started",
+  "icon": "tfc:rock/anvil/granite",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "An alternative to casting tools directly in the early game, and a requirement for higher tier metals, is to use an $(thing)Anvil$(). An anvil is a block which can be used for two different processes: $(l:mechanics/anvils#working)Working$() and $(l:getting_started/primitive_anvils#welding)Welding$(). An anvil can weld double ingots of the metal type needed to create the next tier anvil above it, which will be necessary to work other items from that metal."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "First, you need to acquire a block of $(thing)Raw Rock$(), that is $(thing)Igneous Extrusive$() (Rhyolite, Basalt, Andesite, or Dacite) or $(thing)Igneous Intrusive$() (Granite, Diorite, or Gabbro). You could find and use an exposed block in the world, or you could $(l:getting_started/primitive_anvils#raw_rock)extract one$() from the surrounding rock."
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "stone_anvils",
+      "text": "You will also need any material of $(thing)Hammer$(). In order to make the anvil, simply right click the exposed $(thing)top$() face of one of those raw rock blocks with your $(thing)hammer$(), and voila! An anvil will be formed.$(br2)Anvils have $(l:mechanics/anvils#tiers)tiers$() and the rock anvil is Tier 0 - the lowest tier. It is only able to $(l:getting_started/primitive_anvils#welding)Weld$() Tier I ingots.",
+      "title": "Rock Anvil"
+    },
+    {
+      "type": "tfc:multimultiblock",
+      "text": "Converting the center raw rock to an anvil.",
+      "multiblocks": [ { "pattern": [ [ " 0 " ], [ "RRR" ] ], "mapping": { "0": "AIR", "R": "tfc:rock/raw/gabbro" } }, "tfc:rock_anvil" ]
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "raw_rock",
+      "text": "In order to obtain a raw rock block without breaking it into smaller rocks, it needs to be $(thing)extracted$(). You must mine the blocks on all six sides of a raw rock block - once it is surrounded by air on all sides - it will pop off as a item which can be picked up.",
+      "title": "Obtaining Raw Rock"
+    },
+    {
+      "type": "tfc:multimultiblock",
+      "text": "Mining all six sides of a piece of raw stone - once complete, the center block will pop off as an item.",
+      "multiblocks": [
+        {
+          "pattern": [ [ "   ", " R ", "   " ], [ " R ", "RRR", " R " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "tfc:rock/raw/gabbro", "R": "tfc:rock/raw/gabbro" }
+        },
+        {
+          "pattern": [ [ "   ", "   ", "   " ], [ " R ", "RRR", " R " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "tfc:rock/raw/gabbro", "R": "tfc:rock/raw/gabbro" }
+        },
+        {
+          "pattern": [ [ "   ", "   ", "   " ], [ "   ", "RRR", " R " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "tfc:rock/raw/gabbro", "R": "tfc:rock/raw/gabbro" }
+        },
+        {
+          "pattern": [ [ "   ", "   ", "   " ], [ "   ", " RR", " R " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "tfc:rock/raw/gabbro", "R": "tfc:rock/raw/gabbro" }
+        },
+        {
+          "pattern": [ [ "   ", "   ", "   " ], [ "   ", " RR", "   " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "tfc:rock/raw/gabbro", "R": "tfc:rock/raw/gabbro" }
+        },
+        {
+          "pattern": [ [ "   ", "   ", "   " ], [ "   ", " R ", "   " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "tfc:rock/raw/gabbro", "R": "tfc:rock/raw/gabbro" }
+        },
+        {
+          "pattern": [ [ "   ", "   ", "   " ], [ "   ", " R ", "   " ], [ "   ", " 0 ", "   " ] ],
+          "mapping": { "0": "AIR", "R": "tfc:rock/raw/gabbro" }
+        }
+      ]
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "welding",
+      "text": "Welding is a process through which two items are fused together to create a new item. Welding works the same whether on a $(l:getting_started/primitive_anvils)Stone Anvil$() or a $(l:mechanics/anvils)metal anvil$().$(br2)First, you must place the two items you want to weld on the anvil. You can do this either by using the items on the anvil, or by opening the anvil interface and inserting them in the two leftmost slots.",
+      "title": "Welding"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "You also need to have at least one $(l:mechanics/flux)Flux$() in the anvil to aid the welding process. Then, while both items are $(l:mechanics/heating)hot enough$() to weld - the tooltip will say \"Can Weld\" - you must use any $(thing)Hammer$() on the anvil or press the weld button on the anvil interface. You will hear a hammering sound and the items will be welded together."
+    }
+  ],
+  "read_by_default": true,
+  "sortnum": 6,
+  "extra_recipe_mappings": {
+    "tfc:rock/anvil/granite": 0,
+    "tfc:rock/anvil/diorite": 0,
+    "tfc:rock/anvil/gabbro": 0,
+    "tfc:rock/anvil/rhyolite": 0,
+    "tfc:rock/anvil/basalt": 0,
+    "tfc:rock/anvil/andesite": 0,
+    "tfc:rock/anvil/dacite": 0
+  }
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/anvils.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/anvils.json
@@ -6,7 +6,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Anvils are an important tool required for metalworking, as they allow you to work and weld metal ingots into various different forms.$(br2)Anvils can be useful for both $(l:mechanics/anvils#working)Working$(), which is used to form one piece of metal into another, or $(l:getting_started/primitive_anvils#welding)Welding$(), which is used to fuse two metal items into one solid piece."
+      "text": "Anvils are an important tool required for metalworking, as they allow you to work and weld metal ingots into various different forms.$(br2)$(l:mechanics/anvils#working)Working$() is done to form one piece of metal into another, and $(l:getting_started/primitive_anvils#welding)welding$(), is used to fuse two metal items into one solid piece."
     },
     {
       "type": "patchouli:multiblock",
@@ -18,12 +18,12 @@
     {
       "type": "patchouli:crafting",
       "recipe": "tfc:crafting/metal/anvil/copper",
-      "text": "Anvils can be crafted with $(thing)Double Ingots$() of their respective metal. For your first anvil, you must $(l:getting_started/primitive_anvils#welding)weld$() double ingots first on a $(l:getting_started/primitive_anvils)Stone Anvil$()."
+      "text": "Anvils can be crafted with $(thing)double ingots$() of their respective metal. For your first anvil, you must first $(l:getting_started/primitive_anvils#welding)weld$() double ingots on a $(l:getting_started/primitive_anvils)stone anvil$()."
     },
     {
       "type": "patchouli:text",
       "anchor": "tiers",
-      "text": "Anvils each have a $(thing)Tier$(), which defines what types of material they can work and weld. An anvil can work metals of its current tier, and it can weld metals that are one tier higher.$(br)$(li)$(bold)Tier 0$(): Stone Anvils$(li)$(bold)Tier I$(): Copper$(li)$(bold)Tier II$(): Bismuth Bronze, Black Bronze, Bronze$(li)$(bold)Tier III$(): Wrought Iron$(li)$(bold)Tier IV$(): Steel$(li)$(bold)Tier V$(): Black Steel$(li)$(bold)Tier VI$(): Red Steel, Blue Steel"
+      "text": "Anvils each have a $(thing)tier$(), which defines what types of material they can work and weld. An anvil can work metals of its current tier, and it can weld metals that are one tier higher.$(br)$(li)$(bold)Tier 0$(): Stone Anvils$(li)$(bold)Tier I$(): Copper$(li)$(bold)Tier II$(): Bismuth Bronze, Black Bronze, Bronze$(li)$(bold)Tier III$(): Wrought Iron$(li)$(bold)Tier IV$(): Steel$(li)$(bold)Tier V$(): Black Steel$(li)$(bold)Tier VI$(): Red Steel, Blue Steel"
     },
     {
       "type": "patchouli:text",
@@ -39,7 +39,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "You will then need to select the $(thing)Plan$(), which chooses which item you want to create. $(item)$(k:key.attack)$() on the the scroll button, and then pick one of the items to create. The anvil interface will return, but now you will have selected a plan - the scroll will show the item you are working to create, and the $(thing)Rules$() and $(thing)Target$() will now be populated."
+      "text": "You will then need to select the $(thing)plan$(), which chooses which item you want to create. $(item)$(k:key.attack)$() on the the scroll button, and then pick one of the items to create. The anvil interface will return, but now you will have selected a plan - the scroll will show the item you are working to create, and the $(thing)rules$() and $(thing)target$() will now be populated."
     },
     {
       "type": "patchouli:image",

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/anvils.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/anvils.json
@@ -1,0 +1,85 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Anvils",
+  "category": "tfc:mechanics",
+  "icon": "tfc:metal/anvil/copper",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Anvils are an important tool required for metalworking, as they allow you to work and weld metal ingots into various different forms.$(br2)Anvils can be useful for both $(l:mechanics/anvils#working)Working$(), which is used to form one piece of metal into another, or $(l:getting_started/primitive_anvils#welding)Welding$(), which is used to fuse two metal items into one solid piece."
+    },
+    {
+      "type": "patchouli:multiblock",
+      "multiblock": { "pattern": [ [ "X" ], [ "0" ] ], "mapping": { "X": "#tfc:anvils" } },
+      "name": "",
+      "text": "All types of metal anvils.",
+      "enable_visualize": false
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfc:crafting/metal/anvil/copper",
+      "text": "Anvils can be crafted with $(thing)Double Ingots$() of their respective metal. For your first anvil, you must $(l:getting_started/primitive_anvils#welding)weld$() double ingots first on a $(l:getting_started/primitive_anvils)Stone Anvil$()."
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "tiers",
+      "text": "Anvils each have a $(thing)Tier$(), which defines what types of material they can work and weld. An anvil can work metals of its current tier, and it can weld metals that are one tier higher.$(br)$(li)$(bold)Tier 0$(): Stone Anvils$(li)$(bold)Tier I$(): Copper$(li)$(bold)Tier II$(): Bismuth Bronze, Black Bronze, Bronze$(li)$(bold)Tier III$(): Wrought Iron$(li)$(bold)Tier IV$(): Steel$(li)$(bold)Tier V$(): Black Steel$(li)$(bold)Tier VI$(): Red Steel, Blue Steel"
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "working",
+      "text": "In order to work an item on the anvil, you will need to use the anvil, to open up the anvil interface, seen to the right. On the left, there are two input slots for items - for working, the target item must be in the right hand slot. You will also need a hammer while working, either in the hammer slot on the right of the anvil $(bold)or$() in your main hand. The hammer will gradually take damage as you work the item.",
+      "title": "Working"
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/gui/anvil_empty.png" ],
+      "text": "The anvil interface.",
+      "border": false
+    },
+    {
+      "type": "patchouli:text",
+      "text": "You will then need to select the $(thing)Plan$(), which chooses which item you want to create. $(item)$(k:key.attack)$() on the the scroll button, and then pick one of the items to create. The anvil interface will return, but now you will have selected a plan - the scroll will show the item you are working to create, and the $(thing)Rules$() and $(thing)Target$() will now be populated."
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/gui/anvil_in_use.png" ],
+      "text": "After selecting to create a pickaxe.",
+      "border": false
+    },
+    {
+      "type": "patchouli:text",
+      "text": "In the middle of the anvil screen, there is a bar with two colored indicators. The $(2)green$() pointer, is your current working progress. The $(4)red$() pointer, is the target. Your goal is to line up the current progress, with the target.$(br2)In order to do this, you can use the $(2)green$() and $(4)red$() action buttons, which move your current progress a certain amount, depending on the action taken.",
+      "title": "Targets"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "$(2)Green$() actions will always move your target $(bold)right$(), and $(4)Red$() actions will always move your progress $(bold)left$(). Note that if you move your target off of the progress bar, you will have overworked your item - you will lose the ingot. However, while working, you must also match the $(thing)rules$()..."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The $(thing)rules$(), are the two or three icons shown on the top of the anvil interface. They represent specific actions that must be taken, at specific times, in order for your working to be a success. For example, a rule could be $(2)Bend Second Last$(), meaning the second to last action you take $(bold)must$() be a $(2)Bend$() action.",
+      "title": "Working Rules"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Your last three actions are shown right underneath the rules. When a rule is satisfied, its outline will change to green. Success occurs when all rules are satisfied.$(br2)Finally, you have to be mindful of your item's $(l:mechanics/heating)temperature$(). Metals can only be worked when they are above a certain temperature where the tooltip shows \"Can Work\". You may take an item out and re-heat it during the working process."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Working can be tedious, and take many steps to get correct. However, there is a reward for being efficient. Some items, such as tool heads, when they are worked in a low or minimal amount of steps, receive a Forging Bonus based on how efficiently they were forged. This bonus will then apply to tools that the item is used in, for example, a pickaxe head used to make a pickaxe.",
+      "title": "Forging Bonuses"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "item": "tfc:metal/pickaxe/wrought_iron{\"tfc:forging_bonus\":4}",
+      "title": "Perfectly Forged",
+      "link_recipes": false,
+      "text": "There are four tiers of forging bonus:$(li)Poorly Forged$(li)Well Forged$(li)Expertly Forged$(li)Perfectly Forged$(br2)These bonuses increase the power of your tool - making it break less often, mine faster, and/or do more damage in combat, depending on the tool."
+    }
+  ],
+  "read_by_default": true,
+  "extra_recipe_mappings": {
+    "tag:tfc:anvils": 0
+  }
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/blast_furnace.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/blast_furnace.json
@@ -1,0 +1,66 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Blast Furnace",
+  "category": "tfc:mechanics",
+  "icon": "tfc:blast_furnace",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "A $(thing)Blast Furnace$() is an advanced device which is used in the creation of $(thing)Steel$(). By mixing $(l:getting_started/finding_ores)Iron Ores$(), $(l:tfg_tips/basic_automation)Coke$(), and $(l:mechanics/flux)Flux$() in a controlled, hot environment, you can create a stronger metal than cast or wrought iron.$(br2)To obtain a blast furnace, you will first need a $(l:mechanics/crucible)Crucible$() and a lot of $(thing)Wrought Iron Sheets$()."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfc:crafting/blast_furnace",
+      "text": "Crafting a blast furnace itself requires a $(thing)Crucible$(), along with some of the $(thing)Wrought Iron Sheets$() you will need."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "You will then need to construct the blast furnace, along with its $(thing)Chimney$(). The chimney must be composed out of $(l:mechanics/fire_clay#fire_bricks)Reinforced Fire Bricks$(), as they are strong enough to withstand the intense heat. These can be crafted from fire brick blocks, and either wrought iron or steel sheets. The sheets can be applied to each exposed face of the bricks by $(item)$(k:key.use)$() with the sheet in hand, or crafted into $(l:mechanics/blast_furnace_insulation)Blast Furnace Insulation$()."
+    },
+    {
+      "type": "patchouli:multiblock",
+      "multiblock_id": "tfc:blast_furnace",
+      "name": "A Blast Furnace",
+      "text": "A blast furnace with a minimum height chimney.",
+      "enable_visualize": true
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The blast furnace's chimney can be up to five layers - each layer requiring four $(thing)Fire Bricks$() and twelve $(thing)Wrought Iron Sheets$() to complete. Having more layers increases the total capacity of the blast furnace, allowing it to smelt more steel at once. Each chimney layer, up to a maximum of five, allows the blast furnace to hold four additional ore items."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "In order to use the blast furnace, you must drop items in the top of the chimney - for steel production, you must add an equal number of items of $(l:getting_started/finding_ores)Iron Ores$() and $(l:mechanics/flux)Flux$(). Any iron ores or items that are able to melt into $(thing)Cast Iron$() will do. You will also need to add $(l:tfg_tips/basic_automation)Coke$(), which will be consumed as the blast furnace works."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Using the blast furnace will open the blast furnace interface, seen to the right. In this interface, you will see meters for both ore and fuel contents of the blast furnace. The top right slot must have a $(thing)Tuyere$(), which is a metal pipe used to funnel air into the blast furnace, required to reach the hottest temperatures to smelt steel. A tuyere can be smithed on an $(l:mechanics/anvils)Anvil$()."
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/gui/blast_furnace.png" ],
+      "text": "The Blast Furnace Interface",
+      "border": false
+    },
+    {
+      "type": "patchouli:text",
+      "text": "You will also need a $(l:mechanics/bellows)Bellows$() in order for the Blast Furnace to reach a temperature which will melt iron. This can be placed on any of the four sides of the blast furnace."
+    },
+    {
+      "type": "patchouli:multiblock",
+      "multiblock_id": "tfc:full_blast_furnace",
+      "name": "",
+      "text": "A full size blast furnace with bellows and crucible attached.",
+      "enable_visualize": true
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Finally, to get started, light the blast furnace with a $(l:getting_started/firepit#firestarter)Fire Starter$(), a $(thing)Flint and Pyrite$(), or a $(thing)Flint and Steel$(). It will begin to heat the ores inside. Make sure that the blast furnace continues to have fuel, and use the bellows to add air to the blast furnace after its internal temperature has reached the maximum for charcoal. After the ores inside heat up, they will melt and convert into $(l:mechanics/steel)Pig Iron$()."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "This liquid metal will drip into any metal fluid container placed immediately below the blast furnace, such as a $(l:mechanics/crucible)Crucible$(). It can be cast into ingot molds from the output slot of the crucible and worked into $(l:mechanics/steel)Steel$()."
+    }
+  ],
+  "read_by_default": true
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/blast_furnace.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/blast_furnace.json
@@ -6,7 +6,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "A $(thing)Blast Furnace$() is an advanced device which is used in the creation of $(thing)Steel$(). By mixing $(l:getting_started/finding_ores)Iron Ores$(), $(l:tfg_tips/basic_automation)Coke$(), and $(l:mechanics/flux)Flux$() in a controlled, hot environment, you can create a stronger metal than cast or wrought iron.$(br2)To obtain a blast furnace, you will first need a $(l:mechanics/crucible)Crucible$() and a lot of $(thing)Wrought Iron Sheets$()."
+      "text": "A $(thing)Blast Furnace$() is an advanced device which is used in the creation of $(thing)Steel$(). By mixing $(l:getting_started/finding_ores)Iron Ores$(), $(l:tfg_tips/basic_automation)Coke$() or $(l:beneath/ores_and_minerals#cursecoal)Anthacite$(), and $(l:mechanics/flux)Flux$() in a controlled, hot environment, you can create a stronger metal than cast or wrought iron.$(br2)To obtain a blast furnace, you will first need a $(l:mechanics/crucible)Crucible$() and a lot of $(thing)Wrought Iron Sheets$()."
     },
     {
       "type": "patchouli:crafting",
@@ -15,7 +15,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "You will then need to construct the blast furnace, along with its $(thing)Chimney$(). The chimney must be composed out of $(l:mechanics/fire_clay#fire_bricks)Reinforced Fire Bricks$(), as they are strong enough to withstand the intense heat. These can be crafted from fire brick blocks, and either wrought iron or steel sheets. The sheets can be applied to each exposed face of the bricks by $(item)$(k:key.use)$() with the sheet in hand, or crafted into $(l:mechanics/blast_furnace_insulation)Blast Furnace Insulation$()."
+      "text": "You will then need to construct the blast furnace, along with its $(thing)Chimney$(). The chimney must be composed out of $(l:mechanics/fire_clay#fire_bricks)Reinforced Fire Bricks$(), as they are strong enough to withstand the intense heat. These can be crafted from fire brick blocks, and either cast iron or wrought iron sheets. The sheets can be applied to each exposed face of the bricks by $(item)$(k:key.use)$() with the sheet in hand, or crafted into $(l:mechanics/blast_furnace_insulation)Blast Furnace Insulation$()."
     },
     {
       "type": "patchouli:multiblock",
@@ -30,7 +30,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "In order to use the blast furnace, you must drop items in the top of the chimney - for steel production, you must add an equal number of items of $(l:getting_started/finding_ores)Iron Ores$() and $(l:mechanics/flux)Flux$(). Any iron ores or items that are able to melt into $(thing)Cast Iron$() will do. You will also need to add $(l:tfg_tips/basic_automation)Coke$(), which will be consumed as the blast furnace works."
+      "text": "In order to use the blast furnace, you must drop items in the top of the chimney - for steel production, you must add an equal number of items of $(l:getting_started/finding_ores)Iron Ores$() and $(l:mechanics/flux)Flux$(). Any iron ores or items that are able to melt into $(thing)Cast Iron$() will do. You will also need to add $(l:tfg_tips/basic_automation)Coke$() or $(l:beneath/ores_and_minerals#cursecoal)Anthacite$(), which will be consumed as the blast furnace works."
     },
     {
       "type": "patchouli:text",

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/glassworking_applications.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/glassworking_applications.json
@@ -14,52 +14,43 @@
     },
     {
       "type": "patchouli:text",
-      "text": "$(thing)Glass Panes$() are made with a $(thing)Table Pour$(). A pouring table is made by placing up to sixteen $(thing)Kaolin Clay Blocks$() or $(thing)Brass Blocks$() in a continuous area.$(br2) 1. Add a $(l:mechanics/glassworking)Glass Batch$() to a $(thing)Blowpipe$().$(br) 2. Heat the blowpipe to $(4)$(bold)Faint Red$().$(br) 3. $()$(item)$(k:key.use)$() the $(thing)Blowpipe$() on the top of the table.$(br) 4. Finally $(item)$(k:key.use)$() with a $(l:mechanics/glassworking#paddle)Paddle$() to flatten the glass.",
+      "text": "$(thing)Glass Panes$() are made with a $(thing)Table Pour$(). A pouring table is made by placing up to sixteen $(thing)Kaolin Clay Blocks$() or $(thing)Brass Plated Blocks$() in a continuous area.$(br2) 1. Add a $(l:mechanics/glassworking)Glass Batch$() to a $(thing)Blowpipe$().$(br) 2. Heat the blowpipe to $(4)$(bold)Faint Red$().$(br) 3. $()$(item)$(k:key.use)$() the $(thing)Blowpipe$() on the top of the table.$(br) 4. Finally $(item)$(k:key.use)$() with a $(l:mechanics/glassworking#paddle)Paddle$() to flatten the glass.",
       "title": "Table Pour"
     },
     {
       "type": "patchouli:multiblock",
       "multiblock": {
-        "mapping": {
-			"C": "#tfc:glass_pouring_table",
-			"0": "#tfc:glass_pouring_table"
-		},
-		"pattern": [
-			[ "CCCC", "CCC0", "CCCC", "CCCC" ]
-		]
+        "mapping": { "C": "#tfc:glass_pouring_table", "0": "#tfc:glass_pouring_table" },
+        "pattern": [ [ "CCCC", "CCC0", "CCCC", "CCCC" ] ]
       },
       "text": "Once the glass is cooled, it can be broken with a $(l:mechanics/glassworking#saw)Gem Saw$() to obtain.",
       "border": true
     },
     {
       "type": "patchouli:text",
-      "text": "$(thing)Glass Blocks$() are made with a $(thing)Basin Pour$(). A basin is made by surrounding all sides of an air block except the top with $(thing)Kaolin Clay Blocks$() or $(thing)Brass Blocks$().$(br2) 1. Add a $(l:mechanics/glassworking)Glass Batch$() to a $(thing)Blowpipe$().$(br) 2. Heat the blowpipe to $(4)$(bold)Faint Red$().$(br) 3. $(item)$(k:key.use)$() the $(thing)Blowpipe$() on the top of the table.",
+      "text": "$(thing)Glass Blocks$() are made with a $(thing)Basin Pour$(). A basin is made by surrounding all sides of an air block except the top with $(thing)Kaolin Clay Blocks$() or $(thing)Brass Plated Blocks$().$(br2) 1. Add a $(l:mechanics/glassworking)Glass Batch$() to a $(thing)Blowpipe$().$(br) 2. Heat the blowpipe to $(4)$(bold)Faint Red$().$(br) 3. $(item)$(k:key.use)$() the $(thing)Blowpipe$() on the top of the table.",
       "title": "Basin Pour"
     },
     {
       "type": "patchouli:multiblock",
       "multiblock": {
-        "mapping": {
-			"C": "#tfc:glass_basin_blocks",
-			"0": "#tfc:glass_basin_blocks"
-		},
-		"pattern": [
-			[ " C ", "C C", " C " ],
-			[ "   ", " 0 ", "   " ]
-		]
+        "mapping": { "C": "#tfc:glass_basin_blocks", "0": "#tfc:glass_basin_blocks" },
+        "pattern": [ [ " C ", "C C", " C " ], [ "   ", " 0 ", "   " ] ]
       },
       "text": "Once the glass is cooled, it can be broken with a $(l:mechanics/glassworking#saw)Gem Saw$() to obtain.",
       "border": true
+    },
+    {
+      "type": "patchouli:crafting",
+      "title": "Glassworking Blocks",
+      "recipe": "tfc:crafting/white_kaolin_clay",
+      "recipe2": "tfg:item_application/brass_plated_block"
     },
     {
       "type": "patchouli:text",
       "anchor": "coloring",
       "text": "Glass has a natural color based on the type of $(l:mechanics/glassworking)Glass Batch$() that was used. Other colors can be made using a $(l:mechanics/bowls)Bowl$().$(br2)To use, place the $(l:mechanics/bowls)Bowl$() on the ground, then $(item)$(k:key.use)$() the required $(thing)Powder$(). Before $(thing)Pouring$(), use the $(thing)Blowpipe$() on the bowl to add the powder to the batch.",
       "title": "Coloring Glass"
-    },
-    {
-      "type": "patchouli:text",
-      "text": "$(br2)The next pages show the different combinations of glass types and powder materials to create each color."
     },
     {
       "type": "patchouli:text",
@@ -73,307 +64,108 @@
     {
       "type": "tfc:table_small",
       "strings": [
-        {
-          "text": ""
-        },
-        {
-          "text": "C"
-        },
-        {
-          "text": "T"
-        },
-        {
-          "fill": "0xff42f2"
-        },
-        {
-          "fill": "0x8af3ff"
-        },
-        {
-          "fill": "0x526cff"
-        },
-        {
-          "fill": "0xe3e3e3"
-        },
-        {
-          "fill": "0xe69407"
-        },
-        {
-          "fill": "0xc738c9"
-        },
-        {
-          "fill": "0xffe81c"
-        },
-        {
-          "fill": "0x48ff1f"
-        },
-        {
-          "fill": "0xe01414"
-        },
-        {
-          "fill": "0x0c9400"
-        },
-        {
-          "fill": "0x188a9e"
-        },
-        {
-          "fill": "0x7d4f00"
-        },
-        {
-          "fill": "0x6e059c"
-        },
-        {
-          "fill": "0x7d7d7d"
-        },
-        {
-          "fill": "0xbdbdbd"
-        },
-        {
-          "fill": "0x000000"
-        },
-        {
-          "text": "Silica"
-        },
-        {
-          "fill": "0x3d42a8"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "text": "Hematitic"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3d42a8"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "text": "Olivine"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3d42a8"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "text": "Volcanic"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3d42a8"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0xb33e3e"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        },
-        {
-          "fill": "0x3eb340"
-        }
+        { "text": "" },
+        { "text": "C" },
+        { "text": "T" },
+        { "fill": "0xff42f2" },
+        { "fill": "0x8af3ff" },
+        { "fill": "0x526cff" },
+        { "fill": "0xe3e3e3" },
+        { "fill": "0xe69407" },
+        { "fill": "0xc738c9" },
+        { "fill": "0xffe81c" },
+        { "fill": "0x48ff1f" },
+        { "fill": "0xe01414" },
+        { "fill": "0x0c9400" },
+        { "fill": "0x188a9e" },
+        { "fill": "0x7d4f00" },
+        { "fill": "0x6e059c" },
+        { "fill": "0x7d7d7d" },
+        { "fill": "0xbdbdbd" },
+        { "fill": "0x000000" },
+        { "text": "Silica" },
+        { "fill": "0x3d42a8" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "text": "Hematitic" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3eb340" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3d42a8" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "text": "Olivine" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3eb340" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3d42a8" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "text": "Volcanic" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3eb340" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3d42a8" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0xb33e3e" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" },
+        { "fill": "0x3eb340" }
       ],
       "text": "The availability of glass colors. 'C' is clear, 'T' is tinted. Colors can only be crafted with certain glass batches.",
       "title": "Glass Color Availability",
       "legend": [
-        {
-          "text": "Can be Crafted",
-          "color": "0x3eb340"
-        },
-        {
-          "text": "Cannot be Crafted",
-          "color": "0xb33e3e"
-        },
-        {
-          "text": "Default Color",
-          "color": "0x3d42a8"
-        }
+        { "text": "Can be Crafted", "color": "0x3eb340" },
+        { "text": "Cannot be Crafted", "color": "0xb33e3e" },
+        { "text": "Default Color", "color": "0x3d42a8" }
       ],
       "columns": 18,
       "first_column_width": 35,
@@ -383,10 +175,7 @@
       "top_buffer": 15,
       "draw_background": true
     },
-    {
-      "type": "patchouli:empty",
-      "draw_filler": false
-    },
+    { "type": "patchouli:empty", "draw_filler": false },
     {
       "type": "tfc:glassworking_recipe",
       "anchor": "lamp_glass",
@@ -396,13 +185,13 @@
     {
       "type": "tfc:glassworking_recipe",
       "anchor": "jar",
-      "recipe": "tfc:glassworking/empty_jar",
+      "recipe": "tfc:glassworking/jar",
       "text": "$(l:mechanics/jarring)Jars$() are also made from blown glass, but only silica or hematitic glass."
     },
     {
       "type": "tfc:glassworking_recipe",
       "anchor": "glass_bottle",
-      "recipe": "tfc:glassworking/silica_glass_bottle",
+      "recipe": "tfc:glassworking/silica_bottle",
       "text": "$(thing)Glass Bottles$() can also be made. The quality of the glass bottle depends on the type of glass used to make it."
     },
     {

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/glassworking_applications.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/glassworking_applications.json
@@ -44,7 +44,7 @@
       "type": "patchouli:crafting",
       "title": "Glassworking Blocks",
       "recipe": "tfc:crafting/white_kaolin_clay",
-      "recipe2": "tfg:item_application/brass_plated_block"
+      "text": "$(thing)Brass plated blocks$() can be created by holding a $(thing)brass plate$() and $(item)$(k:key.use)$() on any $(thing)stone brick$()."
     },
     {
       "type": "patchouli:text",
@@ -197,7 +197,7 @@
     {
       "type": "tfc:glassworking_recipe",
       "recipe": "tfc:glassworking/lens",
-      "text": "The $(thing)Lens$() is used for crafting the spyglass, compasses, and other things."
+      "text": "The $(thing)lens$() is used for crafting the $(thing)spyglass$(), $(thing)compass$(), and other things."
     }
   ],
   "read_by_default": true,

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/prospecting.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/prospecting.json
@@ -1,0 +1,59 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Prospecting",
+  "category": "tfc:mechanics",
+  "icon": "tfc:metal/propick/wrought_iron",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "You remembered where you picked up those $(l:getting_started/finding_ores)Small Metal Nuggets$(), right? Finding additional ores may require extensive exploration and mining. You should become very familiar with $(l:tfg_ores/index)Ores and Minerals$(). If you need a specific resource, you must find the rock type it spawns in either under your feet or across the world."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "When picking up small nuggets becomes unsatisfying, it is time to start prospecting to find ore veins:$(br)$(li)Small nuggets occur when an ore vein is located below. If you find the center of a group of nuggets, it's likely that the vein is beneath you.$(li)Exposed ore can occur in cliffs and water bodies, which may be seen from farther away."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "propick",
+      "item": "tfc:metal/propick/copper",
+      "title": "Prospector's Pick",
+      "link_recipes": false,
+      "text": "If you're looking for metal ores or mineral veins (which have no nuggets), and you can't find the vein by guessing, it's time to pull out the $(thing)Prospector's Pick$(). It searches the 25x25x25 area centered on the block clicked, and reports to the action bar the amount and type of ore located."
+    },
+    {
+      "type": "tfc:knapping_recipe",
+      "recipe": "tfc:clay_knapping/propick_head_mold",
+      "text": "To make a Prospector's Pick, you can $(l:getting_started/pottery)knapp$() an unfired mold out of clay as shown above."
+    },
+    {
+      "type": "tfc:heat_recipe",
+      "recipe": "tfc:heating/propick_head_mold",
+      "text": "Once the mold has been $(l:getting_started/pottery)knapped$(), it needs to be $(l:mechanics/heating)fired$() to create a $(thing)Propick Head Mold.$()$(br2)To create the tool head, $(l:getting_started/finding_ores#casting)cast$() liquid metal into the mold."
+    },
+    {
+      "type": "tfc:anvil_recipe",
+      "recipe": "tfc:anvil/copper_propick_head",
+      "text": "A Prospector's Pick Head can also be $(l:mechanics/anvils#working)smithed$() out of an $(thing)ingot$() of any tool metal on an $(l:mechanics/anvils)Anvil$().$(br2)The Prospector's Pick is then created by crafting the tool head with a stick."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The Prospector's Pick will never report finding something when nothing is actually there. However, it may incorrectly say nothing is there when a vein is in range. Higher tier tools will reduce or eliminate these false negatives.$(br2)Prospector's Picks at the same tier give identical results when used on the same block unless ores were removed.$(br2)If the Prospector's Pick finds multiple ores nearby, it will only report one."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Right-clicking a Prospector's Pick on a block will report finding one of these possible results:$(br)$(li)Nothing (may be false)$(li)Traces$(li)A Small Sample$(li)A Medium Sample$(li)A Large Sample$(li)A Very Large Sample$(br2)Very large samples indicate at least eighty and potentially many more blocks."
+    }
+  ],
+  "read_by_default": true,
+  "extra_recipe_mappings": {
+    "tfc:metal/propick/bismuth_bronze": 2,
+    "tfc:metal/propick/black_bronze": 2,
+    "tfc:metal/propick/bronze": 2,
+    "tfc:metal/propick/copper": 2,
+    "tfc:metal/propick/wrought_iron": 2,
+    "tfc:metal/propick/steel": 2,
+    "tfc:metal/propick/black_steel": 2,
+    "tfc:metal/propick/blue_steel": 2,
+    "tfc:metal/propick/red_steel": 2
+  }
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/prospecting.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/prospecting.json
@@ -6,7 +6,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You remembered where you picked up those $(l:getting_started/finding_ores)Small Metal Nuggets$(), right? Finding additional ores may require extensive exploration and mining. You should become very familiar with $(l:tfg_ores/index)Ores and Minerals$(). If you need a specific resource, you must find the rock type it spawns in either under your feet or across the world."
+      "text": "You remembered where you picked up those $(l:getting_started/finding_ores)small metal nuggets$(), right? Finding additional ores may require extensive exploration and mining. You should become very familiar with $(l:tfg_ores/index)ores and minerals$(). If you need a specific resource, you must find the rock type it spawns in either under your feet or across the world."
     },
     {
       "type": "patchouli:text",
@@ -18,26 +18,26 @@
       "item": "tfc:metal/propick/copper",
       "title": "Prospector's Pick",
       "link_recipes": false,
-      "text": "If you're looking for metal ores or mineral veins (which have no nuggets), and you can't find the vein by guessing, it's time to pull out the $(thing)Prospector's Pick$(). It searches the 25x25x25 area centered on the block clicked, and reports to the action bar the amount and type of ore located."
+      "text": "If you're looking for metal ores or mineral veins (which have no nuggets), and you can't find the vein by guessing, it's time to pull out the $(thing)prospector's pick$(). It searches the 25x25x25 area centered on the block clicked, and reports to the action bar the amount and type of ore located."
     },
     {
       "type": "tfc:knapping_recipe",
       "recipe": "tfc:clay_knapping/propick_head_mold",
-      "text": "To make a Prospector's Pick, you can $(l:getting_started/pottery)knapp$() an unfired mold out of clay as shown above."
+      "text": "To make a prospector's pick, you can $(l:getting_started/pottery)knapp$() an unfired mold out of clay as shown above."
     },
     {
       "type": "tfc:heat_recipe",
       "recipe": "tfc:heating/propick_head_mold",
-      "text": "Once the mold has been $(l:getting_started/pottery)knapped$(), it needs to be $(l:mechanics/heating)fired$() to create a $(thing)Propick Head Mold.$()$(br2)To create the tool head, $(l:getting_started/finding_ores#casting)cast$() liquid metal into the mold."
+      "text": "Once the mold has been $(l:getting_started/pottery)knapped$(), it needs to be $(l:mechanics/heating)fired$() to create a $(thing)propick head mold.$()$(br2)To create the tool head, $(l:getting_started/finding_ores#casting)cast$() liquid metal into the mold."
     },
     {
       "type": "tfc:anvil_recipe",
       "recipe": "tfc:anvil/copper_propick_head",
-      "text": "A Prospector's Pick Head can also be $(l:mechanics/anvils#working)smithed$() out of an $(thing)ingot$() of any tool metal on an $(l:mechanics/anvils)Anvil$().$(br2)The Prospector's Pick is then created by crafting the tool head with a stick."
+      "text": "A prospector's pick head can also be $(l:mechanics/anvils#working)smithed$() out of an $(thing)ingot$() of any tool metal on an $(l:mechanics/anvils)Anvil$().$(br2)The prospector's pick is then created by crafting the tool head with a stick."
     },
     {
       "type": "patchouli:text",
-      "text": "The Prospector's Pick will never report finding something when nothing is actually there. However, it may incorrectly say nothing is there when a vein is in range. Higher tier tools will reduce or eliminate these false negatives.$(br2)Prospector's Picks at the same tier give identical results when used on the same block unless ores were removed.$(br2)If the Prospector's Pick finds multiple ores nearby, it will only report one."
+      "text": "The prospector's pick will never report finding something when nothing is actually there. However, it may incorrectly say nothing is there when a vein is in range. Higher tier tools will reduce or eliminate these false negatives.$(br2)Prospector's picks at the same tier give identical results when used on the same block unless ores were removed.$(br2)If the prospector's pick finds multiple ores nearby, it will only report one."
     },
     {
       "type": "patchouli:text",

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/quern.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/quern.json
@@ -1,0 +1,72 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "name": "Quern",
+  "category": "tfc:mechanics",
+  "icon": "tfc:quern",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "The $(thing)Quern$() is a device for grinding items. It can crush raw ores for $(l:tfg_ores/ore_basics#processing)processing$(), as well as make powders, $(l:mechanics/dye)dyes$(), and some other items. It is assembled from a $(thing)Base$() and $(thing)Handstone$()."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfc:crafting/quern",
+      "text": "The base of the quern can be crafted with three $(thing)smooth stone$() and three of any other $(thing)Stone$() blocks.$(br2)Stone blocks can be acquired via $(l:getting_started/primitive_anvils#raw_rock)extraction$(), and smooth blocks with the $(l:mechanics/chisel)chisel$()."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfc:crafting/handstone",
+      "text": "The quern needs a $(thing)Handstone$() to operate."
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/tutorial/quern_empty.png" ],
+      "text": "Point at the top of the quern block and $(item)$(k:key.use)$() to place the handstone.",
+      "border": true
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/tutorial/quern_add_item.png" ],
+      "text": "Use $(item)$(k:key.use)$() on the top of the handstone to add items.",
+      "border": true
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/tutorial/quern_handle.png" ],
+      "text": "Use $(item)$(k:key.use)$() the handle to spin the handstone.",
+      "border": true
+    },
+    {
+      "type": "patchouli:image",
+      "images": [ "tfc:textures/gui/book/tutorial/quern_result.png" ],
+      "text": "The output should appear on the base of the quern. $(item)$(k:key.use)$() anywhere on the base to retrieve it.",
+      "border": true
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "recipe": "tfg:quern/sulfur_powder",
+      "text": "The quern is used to make various $(thing)Powders$() from ores, like $(thing)Sulfur$()."
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "recipe": "tfc:quern/red_dye",
+      "text": "$(l:mechanics/dye)Dye$() can be obtained from various flowers."
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "recipe": "tfg:quern/emerald_powder",
+      "text": "$(thing)Gems$() can also be ground into powder."
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "recipe": "tfc:food/barley_flour",
+      "text": "$(thing)Crops$() can be processed with a knife or quern to acquire $(thing)grain$(), which can further be ground into $(thing)Flour$()."
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "recipe": "tfc:quern/fluxstone",
+      "text": "$(l:mechanics/flux)Flux$() is also obtainable from the quern or crafted with a hammer."
+    }
+  ],
+  "read_by_default": true
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/quern.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/quern.json
@@ -44,28 +44,26 @@
     },
     {
       "type": "tfc:quern_recipe",
-      "recipe": "tfg:quern/sulfur_powder",
-      "text": "The quern is used to make various $(thing)Powders$() from ores, like $(thing)Sulfur$()."
+      "title": "Crushed Ore",
+      "recipe": "tfg:quern/copper_crushed_ore_from_normal_raw_ore",
+      "text": "$(l:tfg_ores/ore_basics#processing)Ores$() can be crushed to obtain more metal."
     },
     {
       "type": "tfc:quern_recipe",
+      "title": "Powders",
+      "recipe": "tfg:quern/sulfur_powder",
+      "text": "The quern is used to make various $(thing)Powders$() from dust, like $(thing)Sulfur$(). $(thing)Gems$() can also be ground into powder."
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "title": "Dyes",
       "recipe": "tfc:quern/red_dye",
       "text": "$(l:mechanics/dye)Dye$() can be obtained from various flowers."
     },
     {
-      "type": "tfc:quern_recipe",
-      "recipe": "tfg:quern/emerald_powder",
-      "text": "$(thing)Gems$() can also be ground into powder."
-    },
-    {
-      "type": "tfc:quern_recipe",
-      "recipe": "tfc:food/barley_flour",
-      "text": "$(thing)Crops$() can be processed with a knife or quern to acquire $(thing)grain$(), which can further be ground into $(thing)Flour$()."
-    },
-    {
-      "type": "tfc:quern_recipe",
-      "recipe": "tfc:quern/fluxstone",
-      "text": "$(l:mechanics/flux)Flux$() is also obtainable from the quern or crafted with a hammer."
+      "type": "patchouli:spotlight",
+      "item": { "tag": "tfc:foods/flour" },
+      "text": "$(thing)Crops$() can be processed with a knife or quern to acquire $(thing)Grain$(), which can further be ground into $(thing)Flour$()."
     }
   ],
   "read_by_default": true

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/hazards.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/hazards.json
@@ -1,64 +1,89 @@
 {
-	"name": "Dealing with Hazards",
-	"icon": "gtceu:hazmat_headpiece",
-	"category": "tfc:tfg_ores",
-	"priority": true,
-	"sortnum": 1,
-	"read_by_default": true,
-	"pages": [
-		{
-			"type": "patchouli:text",
-			"text": "Some ores are hazardous! Having them in your inventory will deal continuous poison damage.$(br2)There's a full $(thing)hazmat suit$(), but that's all the way in $(thing)MV$(), so what can you do instead?$(br2)Here's some tips until TFG is able to update to a newer version of a GregTech that provides its own primitive protection equipment."
-		},
-		{
-			"type": "patchouli:text",
-			"text": "Later, if you want to move hazardous materials around, you can take them out of small vessels and into chests and machines by $(thing)Right-clicking$() on the vessel. This way, it will never enter your inventory!$(br2)Lastly, if you don't enjoy hazards, you can turn them off in the GregTech options."
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Rocks",
-			"item": { "tag": "tfc:rock_knapping" },
-			"text": "The easiest way to prevent hazardous items from entering your inventory is to not pick them up at all.$(br)Filling your inventory with $(thing)Rocks$(), for example, will let you pick and choose which items you want to pick up, letting you deal with the hazardous ones all at once later."
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Containers",
-			"text": "As mentioned, the hazardous materials only deal damage while they are in your $(thing)inventory$(), but that doesn't apply to other containers!$(br)Hazardous materials will not deal damage while they are in another container such as a $(l:mechanics/crankshaft)Backpack$() or $(l:getting_started/pottery#vessel)Vessel$().",
-			"item": "sophisticatedbackpacks:backpack,tfc:ceramic/vessel,tfc:ceramic/large_vessel"
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Armor",
-			"text": "Better armor will reduce the damage taken from hazardous materials.",
-			"item": { "tag": "minecraft:trimmable_armor" }
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Spring Water",
-			"item": "tfc:bucket/spring_water",
-			"text": "Standing in $(thing)Spring Water$() will provide a slow $(thing)Regeneration$() effect."
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Aged Alcohol",
-			"text": "$(thing)Aged Alcohol$() will give potion buffs, some of which you might find useful.$(br2)You can drink them with a $(l:getting_started/pottery#jug)Jug$() or $(l:waterflasks/recipes)Flask$().",
-			"item": "tfcagedalcohol:bucket/aged_beer,tfcagedalcohol:bucket/aged_cider,tfcagedalcohol:bucket/aged_rum,tfcagedalcohol:bucket/aged_sake,tfcagedalcohol:bucket/aged_vodka,tfcagedalcohol:bucket/aged_whiskey,tfcagedalcohol:bucket/aged_corn_whiskey,tfcagedalcohol:bucket/aged_rye_whiskey"
-		},
-		{
-			"type": "patchouli:text",
-			"text": "Aged Beer: Absorption II (20:00)$(br2)Aged Cider: Speed (5:20)$(br2)Aged Rum: Speed II (2:40)$(br2)Aged Sake: Resistance (5:20)$(br2)Aged Vodka: Resistance II (2:40)$(br2)Aged Corn Whiskey: Haste (5:20)$(br2)Aged Rye Whiskey: Haste (5:20)$(br2)Aged Whiskey: Haste II (2:40)"
-		},
-		{
-			"type": "patchouli:spotlight",
-			"item": { "tag": "tfc:foods" },
-			"title": "Nutrition",
-			"text": "Eating better foods with more $(l:getting_started/food_and_water#nutrients)nutrition$() will raise your maximum HP by a significant amount.$(br2)$(l:mechanics/pot#soup)Soups$(), $(l:mechanics/sandwiches)Sandwiches$(), and $(l:mechanics/salad)Salads$() are great for this."
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Bed",
-			"item": { "tag": "minecraft:beds" },
-			"text": "If all else fails, bringing along a bed to respawn is a good idea.$(br2)If you don't have access to $(thing)Wool$() or $(thing)String$(), you can also make a $(l:getting_started/a_place_to_sleep)Thatch Bed$()."
-		}
-	]
+  "name": "Hazardous Materials",
+  "icon": "gtceu:hazmat_headpiece",
+  "category": "tfc:tfg_ores",
+  "priority": true,
+  "sortnum": 1,
+  "read_by_default": true,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "gtceu:uranium_235_nugget",
+      "text": "Some ores and dusts are hazardous and can cause negative effects or even kill you if they are carried in your inventory.$(br2)Certain equipment such as $(thing)masks$(), $(thing)gloves$(), and $(thing)hazardous material suits$() later on can be used to conter these effects"
+    },
+    { "type": "patchouli:crafting", "title": "Face Mask", "recipe": "gtceu:shaped/face_mask" },
+    {
+      "type": "patchouli:spotlight",
+      "item": "gtceu:rubber_gloves",
+      "title": "Rubber gloves",
+      "link_recipes": true,
+      "text": "Rubber gloves can be made from $(l:mechanics/leather_making)leather$()."
+    },
+    {
+      "type": "tfc:knapping_recipe",
+      "recipe": "tfchotornot:leather_knapping/mittens",
+      "text": "First knap the leather into mittens."
+    },
+    {
+      "type": "tfc:sealed_barrel_recipe",
+      "recipe": "tfg:sealed_barrel/prepared_leather_gloves",
+      "text": "Mittens are then soaked in $(thing)Vinegar$(), a mixture of fruit and alcohol."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfg:vat/latex_soaked_gloves",
+      "text": "Prepared leather gloves are then heated in a $(thing)vat$() with $(thing)Vulcanized Latex$(), a mixture of latex and wood ash."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfg:oven/rubber_gloves",
+      "text": "Finally, the latex-soaked gloves are cured in an $(l:firmalife/oven)Oven$()."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Rocks",
+      "item": { "tag": "tfc:rock_knapping" },
+      "text": "The easiest way to prevent hazardous items from entering your inventory is to not pick them up at all.$(br)Filling your inventory with $(thing)Rocks$(), for example, will let you pick and choose which items you want to pick up, letting you deal with the hazardous ones all at once later."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Containers",
+      "text": "Hazardous materials only deal damage while they are in your $(thing)inventory$(), but that doesn't apply to other containers!$(br)Hazardous materials will not deal damage while they are in another container such as a $(l:mechanics/crankshaft)Backpack$() or $(l:getting_started/pottery#vessel)Vessel$(). $(thing)Right-clicking$() while holding a vessel will allow direct transfer of it's contents to and from containers",
+      "item": "sophisticatedbackpacks:backpack,tfc:ceramic/vessel,tfc:ceramic/large_vessel"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Armor",
+      "text": "Better armor will reduce the damage taken from hazardous materials.",
+      "item": { "tag": "minecraft:trimmable_armor" }
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Spring Water",
+      "item": "tfc:bucket/spring_water",
+      "text": "Standing in $(thing)Spring Water$() will provide a slow $(thing)Regeneration$() effect."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Aged Alcohol",
+      "text": "$(thing)Aged Alcohol$() will give potion buffs, some of which you might find useful.$(br2)You can drink them with a $(l:getting_started/pottery#jug)Jug$() or $(l:waterflasks/recipes)Flask$().",
+      "item": "tfcagedalcohol:bucket/aged_beer,tfcagedalcohol:bucket/aged_cider,tfcagedalcohol:bucket/aged_rum,tfcagedalcohol:bucket/aged_sake,tfcagedalcohol:bucket/aged_vodka,tfcagedalcohol:bucket/aged_whiskey,tfcagedalcohol:bucket/aged_corn_whiskey,tfcagedalcohol:bucket/aged_rye_whiskey"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Aged Beer: Absorption II (20:00)$(br2)Aged Cider: Speed (5:20)$(br2)Aged Rum: Speed II (2:40)$(br2)Aged Sake: Resistance (5:20)$(br2)Aged Vodka: Resistance II (2:40)$(br2)Aged Corn Whiskey: Haste (5:20)$(br2)Aged Rye Whiskey: Haste (5:20)$(br2)Aged Whiskey: Haste II (2:40)"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "item": { "tag": "tfc:foods" },
+      "title": "Nutrition",
+      "text": "Eating better foods with more $(l:getting_started/food_and_water#nutrients)nutrition$() will raise your maximum HP by a significant amount.$(br2)$(l:mechanics/pot#soup)Soups$(), $(l:mechanics/sandwiches)Sandwiches$(), and $(l:mechanics/salad)Salads$() are great for this."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Bed",
+      "item": { "tag": "minecraft:beds" },
+      "text": "If all else fails, bringing along a bed to respawn is a good idea.$(br2)If you don't have access to $(thing)Wool$() or $(thing)String$(), you can also make a $(l:getting_started/a_place_to_sleep)Thatch Bed$()."
+    }
+  ]
 }

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/hazards.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/hazards.json
@@ -49,14 +49,8 @@
     {
       "type": "patchouli:spotlight",
       "title": "Containers",
-      "text": "Hazardous materials only deal damage while they are in your $(thing)inventory$(), but that doesn't apply to other containers!$(br)Hazardous materials will not deal damage while they are in another container such as a $(l:mechanics/crankshaft)Backpack$() or $(l:getting_started/pottery#vessel)Vessel$(). $(thing)Right-clicking$() while holding a vessel will allow direct transfer of it's contents to and from containers",
+      "text": "Hazardous materials only deal damage while they are in your $(thing)inventory$(), but that doesn't apply to other containers!$(br)Hazardous materials will not deal damage while they are in another container such as a $(l:tfg_tips/inventory_management)Backpack$() or $(l:getting_started/pottery#vessel)Vessel$(). $(thing)Right-clicking$() while holding a vessel will allow direct transfer of it's contents to and from containers",
       "item": "sophisticatedbackpacks:backpack,tfc:ceramic/vessel,tfc:ceramic/large_vessel"
-    },
-    {
-      "type": "patchouli:spotlight",
-      "title": "Armor",
-      "text": "Better armor will reduce the damage taken from hazardous materials.",
-      "item": { "tag": "minecraft:trimmable_armor" }
     },
     {
       "type": "patchouli:spotlight",

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/hazards.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/hazards.json
@@ -1,6 +1,6 @@
 {
   "name": "Hazardous Materials",
-  "icon": "gtceu:hazmat_headpiece",
+  "icon": "gtceu:raw_plutonium",
   "category": "tfc:tfg_ores",
   "priority": true,
   "sortnum": 1,
@@ -8,7 +8,8 @@
   "pages": [
     {
       "type": "patchouli:spotlight",
-      "item": "gtceu:uranium_235_nugget",
+      "title": "Hazardous Materials",
+      "item": "gtceu:raw_plutonium",
       "text": "Some ores and dusts are hazardous and can cause negative effects or even kill you if they are carried in your inventory.$(br2)Certain equipment such as $(thing)masks$(), $(thing)gloves$(), and $(thing)hazardous material suits$() later on can be used to conter these effects"
     },
     { "type": "patchouli:crafting", "title": "Face Mask", "recipe": "gtceu:shaped/face_mask" },
@@ -30,14 +31,14 @@
       "text": "Mittens are then soaked in $(thing)Vinegar$(), a mixture of fruit and alcohol."
     },
     {
-      "type": "patchouli:crafting",
-      "recipe": "tfg:vat/latex_soaked_gloves",
+      "type": "patchouli:spotlight",
+      "item": "tfg:latex_soaked_gloves",
       "text": "Prepared leather gloves are then heated in a $(thing)vat$() with $(thing)Vulcanized Latex$(), a mixture of latex and wood ash."
     },
     {
-      "type": "patchouli:crafting",
-      "recipe": "tfg:oven/rubber_gloves",
-      "text": "Finally, the latex-soaked gloves are cured in an $(l:firmalife/oven)Oven$()."
+      "type": "patchouli:spotlight",
+      "item": "gtceu:rubber_gloves",
+      "text": "Finally, the latex-soaked gloves are heated in an $(l:firmalife/oven)Oven$()."
     },
     {
       "type": "patchouli:spotlight",

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/ore_basics.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/ore_basics.json
@@ -1,59 +1,54 @@
 {
-	"name": "Mining in TFG",
-	"icon": "gtceu:pyrite_dust",
-	"category": "tfc:tfg_ores",
-	"priority": true,
-	"sortnum": 0,
-	"pages": [
-		{
-			"type": "patchouli:text",
-			"text": "There are two ways of mining ores - with a $(thing)Pickaxe$(), or with a $(thing)Hammer$().$(br)Generally, you should mine anything meltable (such as $(thing)Copper$()) with a hammer, and everything else with a pickaxe, but check JEI if you're unsure."
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Pickaxe",
-			"text": "Breaking an ore block with a pickaxe will yield $(thing)Raw$() ores (poor, normal, or rich), as well as some stone dust. These are not worth much mB each and you will need multiple to make a single ingot, however some other minerals are only useable in this state, such as $(thing)Coal$().",
-			"item": {
-				"tag": "minecraft:pickaxes"
-			}
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Hammer",
-			"text": "Breaking an ore block with a hammer will yield 1-2 $(thing)Crushed Ores$(). These already melt into more mB than Raw ores, but with a little $(l:tfg_ores/ore_basics#processing)extra processing$() they can be worth even more!",
-			"item": {
-				"tag": "forge:tools/hammers"
-			}
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Mining Hammer",
-			"text": "These are basically a pickaxe with a 3x3 range, and will yield $(thing)Raw$() ores as well. Also good for clearing stone after you've hammered the ores out!$(br2)Holding $(thing)Sneak$() will only break a single block at a time.",
-			"item": {
-				"tag": "forge:tools/mining_hammers"
-			}
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Basic ore processing",
-			"anchor": "processing",
-			"item": "gtceu:copper_dust",
-			"text": "To make your crushed ores melt into even more mB, first place them in a crafting grid along with a $(thing)Hammer$(). This will produce $(thing)Impure Dust$().$(br2)To further purify it, throw the dust into some water and wait a few seconds, or right-click a $(thing)Cauldron$() filled with water."
-		},
-		{
-			"type": "patchouli:crafting",
-			"title": "Impure Dust",
-			"recipe": "gtceu:shapeless/crushed_ore_to_dust_copper"
-		},
-		{
-			"type": "patchouli:spotlight",
-			"title": "Steam Age",
-			"text": "Once you have $(thing)Steam machines$(), you can mine everything with a $(thing)Mining Hammer$() - putting Raw ores into a $(thing)Steam Forge Hammer$() or $(thing)Steam Macerator$() gives about the same yield as mining with a Hammer yourself.",
-			"item": "gtceu:hp_steam_forge_hammer,gtceu:hp_steam_macerator"
-		},
-		{
-			"type": "patchouli:text",
-			"text": "Later, when you're in LV, check the LV quests to learn about all the different ore processing machines and extra byproducts they can give you. Remember the $(thing)Macerator$() does not give byproducts until $(thing)HV$()!"
-		}
-	]
+  "name": "Mining in TFG",
+  "icon": "gtceu:pyrite_dust",
+  "category": "tfc:tfg_ores",
+  "priority": true,
+  "sortnum": 0,
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "You will need a $(thing)Pickaxe$() or $(thing)Mining Hammer$() to mine ores.$(br)A regular $(thing)Hammer$() can also break stone type blocks quickly, but will not result in dropped ores."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "gtceu:shaped/pickaxe_copper",
+      "recipe2": "gtceu:shaped/mining_hammer_copper"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Pickaxe",
+      "text": "Breaking an ore block with a pickaxe will yield $(thing)raw ores$() (poor, normal, or rich), as well as some stone dust. These are not worth much mB each and you will need multiple to make a single ingot, however some other minerals are only useable in this state, such as $(thing)Coal$().",
+      "item": { "tag": "minecraft:pickaxes" }
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Mining Hammer",
+      "text": "These are basically a pickaxe with a 3x3 range, and will yield $(thing)raw ores$() as well. Also good for clearing stone after you've hammered the ores out!$(br2)Holding $(thing)Sneak$() will only break a single block at a time.",
+      "item": { "tag": "forge:tools/mining_hammers" }
+    },
+    {
+      "type": "patchouli:spotlight",
+      "title": "Basic ore processing",
+      "anchor": "processing",
+      "item": "gtceu:crushed_copper_ore",
+      "text": "Processing ores will result in much greater amounts of usable metal. The first step is to use a $(l:mechanics/quern)Quern$() to crush the raw ore. This step can be automated in the future with improved machines such as the $(thing)Millstone$(), $(thing)Crushing Wheel$(), $(thing)Macerator$(), and $(thing)Forge Hammer$()."
+    },
+    {
+      "type": "tfc:quern_recipe",
+      "title": "Basic Ore Pocessing",
+      "anchor": "processing",
+      "recipe": "tfg:quern/copper_crushed_ore_from_normal_raw_ore",
+      "text": "Processing ores will result in much greater amounts of usable metal. The first step is to use a $(l:mechanics/quern)Quern$() to crush the raw ore. This step can be automated in the future with improved machines such as the $(thing)Millstone$(), $(thing)Crushing Wheel$(), $(thing)Macerator$(), and $(thing)Forge Hammer$()."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "gtceu:shapeless/crushed_ore_to_dust_copper",
+      "text": "To make your crushed ores melt into even more mB, first place them in a crafting grid along with a $(thing)Hammer$(). This will produce $(thing)Impure Dust$().$"
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfg:ae_transform/copper_dust_from_impure",
+      "text": "To further purify it, throw the dust into some water and wait a few seconds, or right-click a $(thing)Cauldron$() filled with water."
+    }
+  ]
 }

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/ore_basics.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/tfg_ores/ore_basics.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You will need a $(thing)Pickaxe$() or $(thing)Mining Hammer$() to mine ores.$(br)A regular $(thing)Hammer$() can also break stone type blocks quickly, but will not result in dropped ores."
+      "text": "You will need a $(thing)pickaxe$() or $(thing)mining hammer$() to mine ores.$(br2)A regular $(thing)hammer$() can also break stone type blocks quickly, but will not result in dropped ores. It can still be useful for $(l:getting_started/primitive_anvils#raw_rock)extracting$() stone blocks however."
     },
     {
       "type": "patchouli:crafting",
@@ -17,13 +17,13 @@
     {
       "type": "patchouli:spotlight",
       "title": "Pickaxe",
-      "text": "Breaking an ore block with a pickaxe will yield $(thing)raw ores$() (poor, normal, or rich), as well as some stone dust. These are not worth much mB each and you will need multiple to make a single ingot, however some other minerals are only useable in this state, such as $(thing)Coal$().",
+      "text": "Breaking an ore block with a pickaxe will yield $(thing)raw ores$() (poor, normal, or rich), as well as some stone dust. These are not worth much mB each and you will need multiple to make a single ingot, however some other minerals are only useable in this state, such as $(thing)coal$().",
       "item": { "tag": "minecraft:pickaxes" }
     },
     {
       "type": "patchouli:spotlight",
       "title": "Mining Hammer",
-      "text": "These are basically a pickaxe with a 3x3 range, and will yield $(thing)raw ores$() as well. Also good for clearing stone after you've hammered the ores out!$(br2)Holding $(thing)Sneak$() will only break a single block at a time.",
+      "text": "These are basically a pickaxe with a 3x3 range, and will yield $(thing)raw ores$() as well. Also good for clearing stone after you've hammered the ores out!$(br2)Holding $(thing)sneak$() will only break a single block at a time.",
       "item": { "tag": "forge:tools/mining_hammers" }
     },
     {
@@ -34,21 +34,10 @@
       "text": "Processing ores will result in much greater amounts of usable metal. The first step is to use a $(l:mechanics/quern)Quern$() to crush the raw ore. This step can be automated in the future with improved machines such as the $(thing)Millstone$(), $(thing)Crushing Wheel$(), $(thing)Macerator$(), and $(thing)Forge Hammer$()."
     },
     {
-      "type": "tfc:quern_recipe",
-      "title": "Basic Ore Pocessing",
-      "anchor": "processing",
-      "recipe": "tfg:quern/copper_crushed_ore_from_normal_raw_ore",
-      "text": "Processing ores will result in much greater amounts of usable metal. The first step is to use a $(l:mechanics/quern)Quern$() to crush the raw ore. This step can be automated in the future with improved machines such as the $(thing)Millstone$(), $(thing)Crushing Wheel$(), $(thing)Macerator$(), and $(thing)Forge Hammer$()."
-    },
-    {
       "type": "patchouli:crafting",
+      "title": "Purifying dust",
       "recipe": "gtceu:shapeless/crushed_ore_to_dust_copper",
-      "text": "To make your crushed ores melt into even more mB, first place them in a crafting grid along with a $(thing)Hammer$(). This will produce $(thing)Impure Dust$().$"
-    },
-    {
-      "type": "patchouli:crafting",
-      "recipe": "tfg:ae_transform/copper_dust_from_impure",
-      "text": "To further purify it, throw the dust into some water and wait a few seconds, or right-click a $(thing)Cauldron$() filled with water."
+      "text": "To make your crushed ores melt into even more mB, first place them in a crafting grid along with a $(thing)Hammer$(). This will produce $(thing)Impure Dust$(). To purify the dust, throw it in water or $(item)$(k:key.use)$() a $(thing)Cauldron$() filled with water."
     }
   ]
 }


### PR DESCRIPTION
## What is the new behavior?

Update field guide [#853](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/853#issue-2997290737)
## Implementation Details
getting_started/finding_ores
Surface indicators amounts - 10mB to 16mB
Casting amounts - 100mB to 144mB
Change/fix pickaxe recipe. 
Add page and recipes for saw blade for wood, and chisel for working with stone as important unlocks with metal.

Moved Welding from Anvil page to Primitive Anvil page - you'll need to weld on a stone anvil before getting a metal anvil that can work ingots. Update welding links.

Prospecting
Update bad link to ores and minerals to tfg_ores/index
Remove invalid range reference for small indicators
Fix prospector's pick recipe pages

tfg_ores/ore_basics
Yeet hammer references for ore mining, mention it doesn't drop ores
Add crushed ore from quern/millstone, processing guide recipes~
Remove steam age pages - maybe future todo: advanced ore processing with HV+ macerator


Blast Furnace
Link to new blast furnace insulation
Change fuel charcoal to coke requirement and link to tfg_tips/basic_automation for coke oven

todo: dedicated page for coke oven, searchable

Quern
Mention raw ore crushing
Remove mechanical power link
Mention millstone as an automated upgrade
Mention/link to stone extraction, and chisel for smooth stone
Fixed Recipes

Dealing with Hazards
Rename to Hazardous Materials
Update various texts - TBD just delete the whole entry? I think there's still some good info in there though.
Add mask recipe pages
Add rubber glove guide
~~todo: fix type for vat and oven recipes~~

glassworking_applications
Brass Blocks -> Brass Plated Blocks
Add page for Kaolin Clay Block and Brass Plated Block recipes (brass plated block recipe needs fix)
Removed unecessary page that says what to expect on the next page
~~todo:~~Fix recipes
## Outcome

Resolves: #853
## Additional Information

Many recipes still don't show up, even in the newly added and revised sections. They may need templates that TFC does not have. There are probably also many recipes that don't show up on pages I haven't touched yet, but I plan to go through every page eventually to see what can be fixed. If certain recipes can't be shown, revise again to just have text and use patchouli:spotlight type. Please let me know if there is any additional important 0.9 info that deserves to be added to the field guide.

Discord: Risuga
