### PR TITLE
Update small vessel capacity

### DIFF
--- a/defaultconfigs/tfc-server.toml
+++ b/defaultconfigs/tfc-server.toml
@@ -159,7 +159,7 @@
 		#
 		# Tank capacity of a crucible (in mB).
 		#Range: 0 ~ 2147483645
-		crucibleCapacity = 4000
+		crucibleCapacity = 4032
 		#
 		# A modifier for how fast fluid containers empty into crucibles. Containers will empty 1 mB every (this) number of ticks.
 		#Range: > 1
@@ -502,7 +502,7 @@
 		#
 		# Tank capacity of a small vessel (in mB).
 		#Range: 0 ~ 2147483645
-		smallVesselCapacity = 4608
+		smallVesselCapacity = 3024
 		#
 		# The largest (inclusive) size of an item that is allowed in a small vessel.
 		#Allowed Values: TINY, VERY_SMALL, SMALL, NORMAL, LARGE, VERY_LARGE, HUGE

--- a/defaultconfigs/tfc-server.toml
+++ b/defaultconfigs/tfc-server.toml
@@ -502,7 +502,7 @@
 		#
 		# Tank capacity of a small vessel (in mB).
 		#Range: 0 ~ 2147483645
-		smallVesselCapacity = 3000
+		smallVesselCapacity = 4608
 		#
 		# The largest (inclusive) size of an item that is allowed in a small vessel.
 		#Allowed Values: TINY, VERY_SMALL, SMALL, NORMAL, LARGE, VERY_LARGE, HUGE


### PR DESCRIPTION
## What is the new behavior?
TFC cost per ingot was 100mB, and the small vessel held 3000mB for up to 30 ingots by default. TFG changed the ingot amount to 144mB, but small vessel capacity never got changed.

## Implementation Details

~~Changed smallVesselCapcity from 3000 to 4608, or 32*144. Because 32 is nicer than 30.~~

Alternative options - 4,320 (30 * 144), 3024 (21 * 144), or 2880 (20 * 144), to divide evenly by 144.

Updated: smallVesselCapacity 3000 to 3024 (divides evenly into 21), crucibleCapacity from 4000 to 4032 (divides into 28), to stay closest to previous values.

