### PR TITLE
Update carryon-common.toml

### DIFF
--- a/config/carryon-common.toml
+++ b/config/carryon-common.toml
@@ -59,7 +59,7 @@
 	#Entities that CAN be picked up (useWhitelistEntities must be true)
 	allowedEntities = ["tfc:turkey", "tfc:dog", "tfc:isopod", "tfc:lobster", "tfc:frog", "tfc:penguin", "tfc:turtle", "tfc:horseshoe_crab", "tfc:crayfish", "tfc:grouse", "tfc:pheasant", "tfc:peafowl", "tfc:rat", "tfc:cat", "tfc:chicken", "tfc:duck", "tfc:quail", "tfc:rabbit"]
 	#Blocks that CAN be picked up (useWhitelistBlocks must be true)
-	allowedBlocks = ["#forge:chests/wooden", "#storagedrawers:drawers"]
+	allowedBlocks = ["framedblocks:framed_chest", "tfc:wood/chest/*", "tfc:wood/trapped_chest/*", "#forge:chests/wooden"]
 	#Entities that CAN have other entities stacked on top of them (useWhitelistStacking must be true)
 	allowedStacking = []
 


### PR DESCRIPTION
## What is the new behavior?
_This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted._
_Linking an issue can be used alternatively to writing a description._

Changed Carry On's common config file so that players can pick up chests as this seemed to be the intended behavior but was not working.

## Implementation Details
_Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed._

Explicitly added "the framedblocks and terrafirmacraft chests to the whitelist. Also removed the storage drawers as they are not in use.

## Outcome
_A short description of what this PR added/fixed/changed/removed._
_For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"_

The chests can now be picked up by players.

## Additional Information
_This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of._

Using tags in the config file does not seem to work.

## Potential Compatibility Issues
_This section is for defining possible compatibility issues._

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**

noble_was_taken

**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**