### PR TITLE
Add README file to server overrides

### DIFF
--- a/.pakku/server-overrides/README.md
+++ b/.pakku/server-overrides/README.md
@@ -1,0 +1,12 @@
+# Running the TerraFirmaGreg Server Pack
+
+To run the Server Pack:
+
+1. Install the ServerPack in your server of choice
+    * Doing it manually or utilizing a third party website should work fine
+2. Start the Server Pack
+    * You can start it by running the "start_server.bat" file
+    * You should be able to run it using the "BASH" command, assuming your server machine has BASH capabilities
+        * ``bash start_server.bat``
+    * Or just open the batch file if on a windows machine.
+3. The batch file will start the server, install forge on it and then boot up your world.

--- a/pakku.json
+++ b/pakku.json
@@ -16,7 +16,8 @@
         "server.properties",
         "server_starter.conf",
         "server-icon.png",
-        "start_server.bat"
+        "start_server.bat",
+        "README.md"
     ],
     "client_overrides": [
         "resourcepacks"


### PR DESCRIPTION
## What is the new behavior?
#889 

## Implementation Details
Adds a new readme file with details on how to start the server

## Outcome
Fixes #889 

## Additional Information
Starting the server should be pretty much straight forward, i think *most* machines should be able to run the .bat file using the BASH command.

## Potential Compatibility Issues
None