### PR TITLE
FIX: Rubber softlock

### DIFF
--- a/config/ftbquests/quests/chapters/questssteam_age.snbt
+++ b/config/ftbquests/quests/chapters/questssteam_age.snbt
@@ -23,8 +23,10 @@
 		{
 			id: "23A27702FF816291"
 			linked_quest: "6903C72A254A7B08"
+			shape: "octagon"
+			size: 2.0d
 			x: -13.5d
-			y: 7.5d
+			y: 14.5d
 		}
 		{
 			id: "1F1E7097C015BE33"
@@ -1344,7 +1346,6 @@
 			dependencies: [
 				"69BDD31A69062B6C"
 				"43D0B4F2ACB9931B"
-				"6903C72A254A7B08"
 				"2C35D4E01AEC02AA"
 			]
 			description: ["{quests.steam_age.lv_circuit.desc}"]

--- a/config/ftbquests/quests/chapters/queststfc_tips.snbt
+++ b/config/ftbquests/quests/chapters/queststfc_tips.snbt
@@ -1116,7 +1116,7 @@
 		}
 		{
 			dependencies: [
-				"1DF4DBE41BB0B6FD"
+				"5F3063C539C9CBBF"
 				"4891E995D3EC2BD1"
 			]
 			description: ["{quests.tfg_tips.create_rubber_ingot.desc}"]

--- a/kubejs/server_scripts/vintage_improvements/recipes.js
+++ b/kubejs/server_scripts/vintage_improvements/recipes.js
@@ -24,7 +24,7 @@ function registerVintageImprovementsRecipes(event) {
 		'DAG',
 		'FCF'
 	], {
-		A: 'gtceu:ulv_machine_hull',
+		A: 'gtceu:ulv_machine_casing',
 		B: 'greate:steel_mechanical_pump',
 		C: 'create:mechanical_piston',
 		D: '#forge:springs/wrought_iron',


### PR DESCRIPTION

## What is the new behavior?
Fixes #959

## Implementation Details
- Made Vacuum Chamber craftable with ULV Casings rather than hulls (being the precursor to ULV vac tubes I think this is fair). This lets them craftable without rubber-requiring red alloy cables which was the issue.
- Quest updates to show rubber line changes more clearly (remove dependency on extractor, change it to Vac chamber)

## Outcome
Fixes #959

## Additional Information
N/A

## Potential Compatibility Issues
N/A