### PR TITLE
Quick Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed rebar support recipe crash. (Redeix)
 - Fixed red steel flask dupe. (Redeix)
 - Fixed red alloy recipe inconsistency. (Redeix)
+- Fixed blue steel backpack block lang. (Redeix)
 
 ## [0.9.4] - 06.05.2025
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 ### Changes
+- Fixed hide duping recipes. (Redeix)
+- Added quest book and field guide instances for fishing nets. (Redeix)
+- Fixed rebar support recipe crash. (Redeix)
+- Fixed red steel flask dupe. (Redeix)
+- Fixed red alloy recipe inconsistency. (Redeix)
 
 ## [0.9.4] - 06.05.2025
 ### Changes

--- a/config/ftbquests/quests/chapters/queststfc_tips.snbt
+++ b/config/ftbquests/quests/chapters/queststfc_tips.snbt
@@ -3344,6 +3344,27 @@
 			y: 6.0d
 		}
 		{
+			dependencies: ["150B7C5CD152E1BA"]
+			description: ["{quests.tfg_tips.fishing_net.desc}"]
+			id: "75C6BF1C9405B4BF"
+			subtitle: "{quests.tfg_tips.fishing_net.subtitle}"
+			tasks: [{
+				id: "37DD99D32072ADBF"
+				item: {
+					Count: 1
+					id: "ftbfiltersystem:smart_filter"
+					tag: {
+						"ftbfiltersystem:filter": "ftbfiltersystem:item_tag(forge:tools/fishing_nets)"
+					}
+				}
+				title: "{quests.tfg_tips.fishing_net.task}"
+				type: "item"
+			}]
+			title: "{quests.tfg_tips.fishing_net.title}"
+			x: -1.5d
+			y: 6.0d
+		}
+		{
 			dependencies: ["5C01BDDA66249D7B"]
 			description: ["{quests.tfg_tips.sleeping_bags.desc}"]
 			id: "0EEB7293B5CA65D8"

--- a/kubejs/assets/create/lang/en_us.json
+++ b/kubejs/assets/create/lang/en_us.json
@@ -68,6 +68,7 @@
   "block.create.small_granite_brick_wall": "Small Chert Brick Wall",
   "block.create.layered_granite": "Layered Chert",
   "block.create.granite_pillar": "Chert Pillar",
+  "block.create.netherite_backtank": "Blue Steel Backtank",
   "item.create.netherite_diving_helmet.tooltip.summary": "Together with a _Blue Steel Backtank_, this can protect you from _extreme heat_. To be effective, _Legs and Feet_ have to be covered in a _Blue Steel Diving Equipment_, too.",
   "item.create.netherite_backtank": "Blue Steel Backtank",
   "item.create.netherite_diving_helmet": "Blue Steel Diving Helmet",

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/fishing_nets.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/mechanics/fishing_nets.json
@@ -1,0 +1,20 @@
+{
+	"name": "Fishing Nets",
+	"icon": "tfg:fishing_net/brass",
+	"category": "tfc:mechanics",
+	"priority": true,
+	"pages": [
+		{
+			"type": "patchouli:spotlight",
+			"title": "Fishing Nets",
+			"item": { "tag": "forge:tools/fishing_nets" },
+			"text": "Tired of hunting down fish with spears? Or loosing a floppy catch while $(l:mechanics/fishing)fishing$()? Craft a $(thing)Fishing Net$() to scoop up your dinner.$(br)To use a fishing net; right click on a fish entity to capture the fish into your inventory. Different tier fshing nets all act the same, but have different durability."
+		},
+		{
+			"type": "patchouli:crafting",
+			"title": "Wood Fishing Net",
+			"recipe": "tfc:kjs/damage/shaped/fishing_net/wood",
+			"text": "A basic $(item)Wood Fishing Net$()."
+		}
+	]
+}

--- a/kubejs/assets/tfg/lang/en_us.json
+++ b/kubejs/assets/tfg/lang/en_us.json
@@ -2226,5 +2226,9 @@
   "quests.tfg_tips.fuck_go_back.desc": "To escape &4The Beneath&r, you need to reach the upper levels of the cave system, near the &dBedrock Ceiling.&r Staying still for a couple of seconds near the roof will transport you back to the &bOverworld&r, right where you stood on to get in.",
   "quests.tfg_tips.piglin_bartering.title": "Piglin Bartering",
   "quests.tfg_tips.piglin_bartering.subtitle": "We are not alone apparently",
-  "quests.tfg_tips.piglin_bartering.desc": "The curious inhabitants of &4The Beneath&r have items to offer... Trade gold with them to get some useful resource, such as small amounts of &aMetals&r or &aLeather.&r\nCheck out the &2Field Guide&r for details about barter trades."
+  "quests.tfg_tips.piglin_bartering.desc": "The curious inhabitants of &4The Beneath&r have items to offer... Trade gold with them to get some useful resource, such as small amounts of &aMetals&r or &aLeather.&r\nCheck out the &2Field Guide&r for details about barter trades.",
+  "quests.tfg_tips.fishing_net.title": "Fishing Nets",
+  "quests.tfg_tips.fishing_net.subtitle": "Not the socks, sorry.",
+  "quests.tfg_tips.fishing_net.desc": "Fish have never been so easy to catch. A right-click away from a hearty meal.",
+  "quests.tfg_tips.fishing_net.task": "Any #forge:tools/fishing_nets"
 }

--- a/kubejs/server_scripts/gregtech/recipes.tfcmetals.js
+++ b/kubejs/server_scripts/gregtech/recipes.tfcmetals.js
@@ -59,6 +59,14 @@ function registerGTCEuTFCMetalsRecipes(event)
 
 	// red alloy, because crucible always makes 4+1=5
 
+	event.remove({ id: 'gtceu:alloy_blast_smelter/red_alloy' })
+	event.recipes.gtceu.alloy_blast_smelter('tfg:red_alloy_mixer')
+		.itemInputs('1x gtceu:copper_dust', '4x minecraft:redstone')
+		.outputFluids(Fluid.of('gtceu:red_alloy', 720))
+		.circuit(5)
+		.duration(75)
+		.EUt(GTValues.VA[GTValues.LV])
+
 	event.remove({ id: 'gtceu:mixer/red_alloy' })
 	event.recipes.gtceu.mixer('tfg:red_alloy_mixer')
 		.itemInputs('1x gtceu:copper_dust', '4x minecraft:redstone')

--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -259,57 +259,69 @@ const registerTFCRecipes = (event) => {
 		'prepared',
 		'sheepskin'
 	];
-	
-	const sizes = [
-		'small',
-		'medium',
-		'large'
-	];
-	
-	stages.forEach((stage) => {
-		sizes.forEach((size, index) => {
-			// Find the next larger size.
-			const nextLarger = sizes[index + 1];
-			
-			// If a larger size exists, sew the hides together.
-			if (nextLarger) {
-				event.recipes.tfc.damage_inputs_shapeless_crafting(
-					event.shapeless(`1x tfc:${nextLarger}_${stage}_hide`, [
-						`2x tfc:${size}_${stage}_hide`,
-						'#tfc:sewing_needles',
-						'#forge:string',
-						'tfc:glue'
-					]).id(`tfg:tfc/${size}_to_${nextLarger}_${stage}_hide`)
-				)
 
-				event.recipes.gtceu.assembler(`tfg:gtceu/assembler/${size}_to_${nextLarger}_${stage}_hide`)
-					.inputFluids(Fluid.of('gtceu:glue', 25))
-					.itemOutputs(`1x tfc:${nextLarger}_${stage}_hide`)
-					.itemInputs(`2x tfc:${size}_${stage}_hide`)
-					.duration(60)
-					.circuit(7)
-					.EUt(GTValues.VA[GTValues.ULV])
-			}
+	stages.forEach(stage => {
+		//Combining
+		event.recipes.tfc.damage_inputs_shapeless_crafting(
+			event.shapeless(`1x tfc:medium_${stage}_hide`, [
+				`2x tfc:small_${stage}_hide`,
+				'#tfc:sewing_needles',
+				'#forge:string',
+				'tfc:glue'
+			]).id(`tfg:tfc/small_to_medium_${stage}_hide`)
+		)
+		event.recipes.tfc.damage_inputs_shapeless_crafting(
+			event.shapeless(`1x tfc:large_${stage}_hide`, [
+				`3x tfc:small_${stage}_hide`,
+				'#tfc:sewing_needles',
+				'#forge:string',
+				'tfc:glue'
+			]).id(`tfg:tfc/small_to_large_${stage}_hide`)
+		)
 
-			// Find the next smaller size.
-			const nextSmaller = sizes[index - 1];
-			
-			// If a smaller size exists, cut the hide.
-			if (nextSmaller) {
-				event.recipes.tfc.damage_inputs_shapeless_crafting(
-					event.shapeless(`2x tfc:${nextSmaller}_${stage}_hide`, [
-						`1x tfc:${size}_${stage}_hide`,
-						'#forge:shears'
-					]).id(`tfg:tfc/${size}_to_${nextSmaller}_${stage}_hide`)
-				)
+		event.recipes.gtceu.assembler(`tfg:gtceu/assembler/small_to_medium_${stage}_hide`)
+			.inputFluids(Fluid.of('gtceu:glue', 25))
+			.itemOutputs(`1x tfc:medium_${stage}_hide`)
+			.itemInputs(`2x tfc:small_${stage}_hide`)
+			.duration(60)
+			.circuit(7)
+			.EUt(GTValues.VA[GTValues.ULV])
 
-				event.recipes.gtceu.assembler(`tfg:gtceu/assembler/${size}_to_${nextSmaller}_${stage}_hide`)
-					.itemOutputs(`2x tfc:${nextSmaller}_${stage}_hide`)
-					.itemInputs(`1x tfc:${size}_${stage}_hide`)
-					.duration(60)
-					.circuit(4)
-					.EUt(GTValues.VA[GTValues.ULV])
-			}
-		});
+		event.recipes.gtceu.assembler(`tfg:gtceu/assembler/small_to_large_${stage}_hide`)
+			.inputFluids(Fluid.of('gtceu:glue', 25))
+			.itemOutputs(`1x tfc:large_${stage}_hide`)
+			.itemInputs(`3x tfc:small_${stage}_hide`)
+			.duration(60)
+			.circuit(9)
+			.EUt(GTValues.VA[GTValues.ULV])
+
+		//Cutting
+		event.recipes.tfc.damage_inputs_shapeless_crafting(
+			event.shapeless(`2x tfc:small_${stage}_hide`, [
+				`1x tfc:medium_${stage}_hide`,
+				'#forge:shears'
+			]).id(`tfg:tfc/medium_to_small_${stage}_hide`)
+		)
+
+		event.recipes.tfc.damage_inputs_shapeless_crafting(
+			event.shapeless(`3x tfc:small_${stage}_hide`, [
+				`1x tfc:large_${stage}_hide`,
+				'#forge:shears'
+			]).id(`tfg:tfc/large_to_small_${stage}_hide`)
+		)
+
+		event.recipes.gtceu.assembler(`tfg:gtceu/assembler/medium_to_small_${stage}_hide`)
+			.itemOutputs(`2x tfc:small_${stage}_hide`)
+			.itemInputs(`1x tfc:medium_${stage}_hide`)
+			.duration(60)
+			.circuit(4)
+			.EUt(GTValues.VA[GTValues.ULV])
+
+		event.recipes.gtceu.assembler(`tfg:gtceu/assembler/large_to_small_${stage}_hide`)
+			.itemOutputs(`3x tfc:small_${stage}_hide`)
+			.itemInputs(`1x tfc:large_${stage}_hide`)
+			.duration(60)
+			.circuit(6)
+			.EUt(GTValues.VA[GTValues.ULV])
 	});
 }

--- a/kubejs/server_scripts/tfc/recipes.metals.js
+++ b/kubejs/server_scripts/tfc/recipes.metals.js
@@ -330,4 +330,9 @@ function registerTFCMetalsRecipes(event) {
 			.EUt(GTValues.VA[GTValues.LV])
 	})})
 	//#endregion
+	event.remove({id: 'waterflasks:heating/red_steel_unfinished_red_steel_flask'})
+
+    event.recipes.tfc.heating('waterflasks:unfinished_red_steel_flask', 1500)
+        .resultFluid(Fluid.of('tfc:metal/red_steel', 144))
+		.id('waterflasks:tfc/heating/unfinished_red_steel_flask')
 }

--- a/kubejs/server_scripts/tfg/recipes.supports.js
+++ b/kubejs/server_scripts/tfg/recipes.supports.js
@@ -168,7 +168,6 @@ function registerTFGSupportRecipes(event) {
 		.EUt(GTValues.VA[GTValues.ULV])
 
 	// Metal Supports
-	event.recipes.tfc.damage_inputs_shaped_crafting(
 		event.shaped('8x tfg:rebar_support', [
 			'BA ',
 			'AC '
@@ -176,7 +175,7 @@ function registerTFGSupportRecipes(event) {
 			A: ChemicalHelper.get(TagPrefix.rod, GTMaterials.Steel, 1),
 			B: ChemicalHelper.get(TagPrefix.wireFine, GTMaterials.Steel, 1),
 			C: '#forge:tools/wire_cutters'
-		}).id('tfg:shaped/rebar_support'))
+		}).id('tfg:shaped/rebar_support')
 
 	event.recipes.gtceu.assembler('tfg:gtceu/assembler/rebar_support')
 		.circuit(4)


### PR DESCRIPTION
- Fixed hide duping recipes.
- Added quest book and field guide instances for fishing nets.
- Fixed rebar support recipe crash.
- Fixed red steel flask dupe.
- Fixed red alloy recipe inconsistency.
- Fixed blue steel backpack block lang.