### PR TITLE
Field guide updates - Getting Started/Casting (Wood Tongs, Small Vessel Capacity), R&R/Concrete Roads (TFG Instructions)

### DIFF
--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
@@ -53,12 +53,17 @@
     },
     {
       "type": "patchouli:text",
-      "text": "First, open the $(thing)Small Vessel$() and put the ores inside. Count up the total amount of metal in the ores carefully! Then, you need to build a $(l:getting_started/pit_kiln)Pit Kiln$() with the filled small vessel inside. As the vessel heats, the ores inside it will melt, and you'll be left with a vessel of molten metal.$(br2)Take the vessel out and $(item)$(k:key.use)$() while holding it, to open the $(thing)Casting$() interface."
+      "text": "First, open the $(thing)Small Vessel$() and put the ores inside. Count up the total amount of metal in the ores carefully! The vessel can only hold up to 3024mB of molten metal, excess will be lost. Then, you need to build a $(l:getting_started/pit_kiln)Pit Kiln$() with the filled small vessel inside. As the vessel heats, the ores inside it will melt, and you'll be left with a vessel of molten metal."
+    },
+    {
+      "type": "patchouli:crafting",
+      "recipe": "tfchotornot:crafting/tongs/wood",
+      "text": "Careful, the vessel will be hot! Craft $(thing)Wooden Tongs$() with two sticks and a knife and hold them in your off hand to handle the hot vessel safely. (This is a $(thing)Shapeless Recipe$(), you can make it in your inventory crafting grid)"
     },
     {
       "type": "patchouli:image",
       "images": [ "tfc:textures/gui/book/gui/casting.png" ],
-      "text": "The Casting Interface.",
+      "text": "Hold the vessel and $(item)$(k:key.use)$() to open the $(thing)Casting$() interface.",
       "border": false
     },
     {

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/roadsandroofs/concrete_roads.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/roadsandroofs/concrete_roads.json
@@ -1,0 +1,63 @@
+{
+  "name": "Concrete Roads",
+  "category": "tfc:roadsandroofs",
+  "icon": "rnr:concrete_road_panel",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Concrete roads are the fastest variety of road that can be constructed, offering a 30% movement speed bonus when properly constructed. However, road builders must be diligent when constructing concrete roads to prevent them from cracking or being trodden on while wet, as this will remove the speed bonus."
+    },
+    {
+      "type": "patchouli:image",
+      "title": "Concrete Road",
+      "images": [ "rnr:textures/gui/book/concrete_road.png" ],
+      "border": true
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "liquid_concrete",
+      "item": "gtceu:concrete_bucket",
+      "title": "Concrete Crafting",
+      "text": "The first step in making a concrete road is mixing the liquid concrete. Use a $(thing)Mixer$() to combine water with any two stone dusts, one of either calcite or marble dust, and gypsum dust, or any three stone dusts with clay dust to make $(thing)Liquid Concrete$()."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "wet_concrete",
+      "item": "rnr:bucket/concrete",
+      "title": "Concrete Crafting",
+      "text": "Then add the liquid concrete in a $(thing)Mixer$() set to $(thing)Programmed Circuit #7$() with more water to dilute it into $(thing)Wet Concrete Mix$()."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Once $(thing)Wet Concrete$() has been mixed, it can be picked up in a bucket and placed on a $(thing)Base Course Block$() where it will spread to adjacent blocks. The concrete will harden after one day, and until it hardens care must be taken that no creatures walk through the wet concrete as this will create an uneven surface that provides no speed bonus. Footprints can be smoothed out with a $(thing)Mattock$()."
+    },
+    {
+      "type": "patchouli:image",
+      "title": "Pouring a Concrete Road",
+      "images": [ "rnr:textures/gui/book/wet_concrete.png" ],
+      "border": true
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Shrinkage cracking is also a concern as concrete sets. If concrete is poured in areas more than four blocks wide, blocks that are farther than two blocks from the nearest $(thing)Edge$(), $(thing)Control Joint$(), or $(thing)Textured Finish$() will crack when set. This can be prevented by pouring concrete in smaller areas, using a $(thing)Mattock$() to add $(thing)Control Joints$(), or by applying a $(thing)Textured Finish$()."
+    },
+    {
+      "type": "patchouli:image",
+      "title": "Control Joints",
+      "images": [ "rnr:textures/gui/book/control_joints.png" ],
+      "border": true
+    },
+    {
+      "type": "patchouli:text",
+      "text": "$(thing)Textured Finishes$() are created by pressing $(thing)Bricks$(), $(thing)Flagstones$(), or $(thing)Smooth Stone Blocks$() into drying concrete to create an architectural finish. These blocks also act as $(thing)Control Joints$() for preventing cracking. Once concrete has finished drying, a $(thing)Chisel$() can be used to form slabs and stairs."
+    },
+    {
+      "type": "patchouli:image",
+      "title": "Faux Sett Road",
+      "images": [ "rnr:textures/gui/book/faux_sett.png" ],
+      "border": true
+    }
+  ],
+  "read_by_default": true,
+  "sortnum": 20
+}


### PR DESCRIPTION
## What is the new behavior?
Field guide updates:

Getting started, ores and casting - Mentioned Small Vessel capacity and loss for overflow. Added wooden tongs page, to pick up hot vessel.

Roads and roofs, concrete roads - Updated instructions on how to obtain liquid concrete mix to pour in TFG, added highlights for important points in paragraphs.
