### PR TITLE
Buff Large Boiler Fuel Efficiency

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1056,6 +1056,25 @@ const registerGTCEURecipes = (event) => {
 
 	//#endregion 
 
+    //#region Large boilers fuel rebalance
+
+    // Balance is based on adjusting to match singeblock boiler efficiency
+    // High Pressure Steam Solid Boiler produces 288,000 mB steam/coke
+	// High Pressure Steam Liquid Boiler produces 432 mB steam/creosote
+    // By Defualt: Large Bronze Boiler produces 50mB steam/creosote, 32000mB steam/coke
+    // This is a factor of 9x for solids, 8.64x for liquids
+	// Large boiler fuel burn time is multiplied by 9, resulting in less fuel used over time for the same amount of steam produced per tick
+
+    event.findRecipes({ id: /^gtceu:large_boiler\/.*/, type: "gtceu:large_boiler" }).forEach(large_boiler_recipe => {
+
+        let recipe_duration = large_boiler_recipe.json.getAsJsonPrimitive("duration").asInt
+
+        large_boiler_recipe.json.remove("duration")
+        large_boiler_recipe.json.add("duration", recipe_duration * 9)
+	})
+
+	//#endregion
+
 	// TODO: Greate again...
 	event.shapeless('gtceu:programmed_circuit', ['minecraft:stick', '#forge:tools/wrenches'])
 		.id('tfg:shapeless/programmed_circuit_from_stick')

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1060,10 +1060,10 @@ const registerGTCEURecipes = (event) => {
 
     // Balance is based on adjusting to match singeblock boiler efficiency
     // High Pressure Steam Solid Boiler produces 288,000 mB steam/coke
-	// High Pressure Steam Liquid Boiler produces 432 mB steam/creosote
+    // High Pressure Steam Liquid Boiler produces 432 mB steam/creosote
     // By Defualt: Large Bronze Boiler produces 50mB steam/creosote, 32000mB steam/coke
     // This is a factor of 9x for solids, 8.64x for liquids
-	// Large boiler fuel burn time is multiplied by 9, resulting in less fuel used over time for the same amount of steam produced per tick
+    // Large boiler fuel burn time is multiplied by 9, resulting in less fuel used over time for the same amount of steam produced per tick
 
     event.findRecipes({ id: /^gtceu:large_boiler\/.*/, type: "gtceu:large_boiler" }).forEach(large_boiler_recipe => {
 


### PR DESCRIPTION
## What is the new behavior?
Per https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/897, fuel consumption rates in a large bronze boiler was extremely inefficient when compared to an equivalent amount of single block boilers for steam generation. This resulted in (unlimited) lava being the only viable fuel source for large bronze boilers. With infinite lava being somewhat harder to obtain in 0.9, this will allow for alternative fuel sources to be reasonably usable.

## Implementation Details

Fuel burn time for large boilers increased by a factor of 9 across all fuel recipes.
Rough math is here - https://docs.google.com/spreadsheets/d/1sUxEC2wlal7e6ZZL-gg3Efy8ZewM7zUoNVPOG8WlejE/edit?usp=sharing

## Outcome

Previously, an equivalent of 26.6 liquid steam boilers to a 100% large bronze boiler to generate 800mB/T steam would cost 37 mB/s of creosote in the lsb vs 320 mB/s for the lbb (8.64 times as much). An equivalent 53.3 solid steam boilers to 100% lbb costs 0.055 coke/s vs 0.5 coke/s (9 times as much).

For reference, compared to the rate of creosote generation of a coke oven cooking logs - It takes 6.66 coke ovens to run 26.6 lsb full time to make 800mB/t of steam, and 57.6 coke ovens to run a lbb full time to make the same amount of steam. For the amount needed to power an ebf, (8 lsb, or 30% lbb), it would be 2 coke ovens for the lsbs, or 17.28 for the lbb.

With a 9x boost to large boiler efficiency, both the 30% lbb and 8 lsb would now need 2 coke ovens running on logs, 1 running on coal, or 0.5 running on rich coal to power an ebf.

A 100% lbb can use up to 6.4 coke ovens on logs, 3.2 on coal, and 0.8 on rich coal. Similar for solid fuels, with the LBB having the advantage of being able to accept either liquid or solid in the same machine.

Original code from https://github.com/ThePansmith/Monifactory/pull/1678