### PR TITLE
Add wrought iron alternatives for early game cast iron recipes

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1035,7 +1035,7 @@ const registerCreateRecipes = (event) => {
 	], {
 		A: '#forge:screws/copper',
 		B: 'tfc:metal/boots/copper',
-		C: '#forge:ingots/iron',
+		C: '#createdeco:internal/ingots/iron_ingots',
 		D: 'firmaciv:large_waterproof_hide'
 	}).id('tfg:create/shaped/copper_diving_boots')
 

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1035,9 +1035,19 @@ const registerCreateRecipes = (event) => {
 	], {
 		A: '#forge:screws/copper',
 		B: 'tfc:metal/boots/copper',
-		C: '#createdeco:internal/ingots/iron_ingots',
+		C: '#forge:ingots/iron',
 		D: 'firmaciv:large_waterproof_hide'
-	}).id('tfg:create/shaped/copper_diving_boots')
+	}).id('tfg:create/shaped/copper_diving_boots_cast_iron')
+
+	event.shaped('create:copper_diving_boots', [
+		'ABA',
+		'CDC'
+	], {
+		A: '#forge:screws/copper',
+		B: 'tfc:metal/boots/copper',
+		C: '#forge:ingots/wrought_iron',
+		D: 'firmaciv:large_waterproof_hide'
+	}).id('tfg:create/shaped/copper_diving_boots_wrought_iron')
 
 	// Netherite backtank
 	event.shaped('create:netherite_backtank', [

--- a/kubejs/server_scripts/gregtech/recipes.machines.js
+++ b/kubejs/server_scripts/gregtech/recipes.machines.js
@@ -749,6 +749,24 @@ function registerGTCEuMachineRecipes(event) {
 			.category(GTRecipeCategories.ARC_FURNACE_RECYCLING)
 	})
 
+	// Wooden crate
+	event.recipes.shaped('gtceu:wood_crate', [
+		'ABA',
+		'BCB',
+		'ABA'
+	], {
+		A: '#forge:screws/wrought_iron',
+		B: '#minecraft:planks',
+		C: '#forge:tools/saws'
+	}).id('tfg:shaped/wooden_crate_wrought_iron')
+
+	event.recipes.gtceu.assembler('gtceu:wood_crate')
+		.itemInputs('4x #minecraft:planks', '4x #forge:screws/wrought_iron')
+		.itemOutputs('gtceu:wood_crate')
+		.duration(100)
+		.EUt(16)
+		.circuit(5)
+
 	// Steam multi parts
 
 	event.shaped('gtceu:steel_machine_casing', [

--- a/kubejs/server_scripts/tfg/tags.js
+++ b/kubejs/server_scripts/tfg/tags.js
@@ -129,6 +129,12 @@ const registerTFGItemTags = (event) => {
 
 	// #endregion
 
+	// Use either cast or wrought iron
+	event.add('forge:double_iron_ingots', 'tfc:metal/double_ingot/cast_iron')
+	event.add('forge:double_iron_ingots', 'gtceu:wrought_iron_double_ingot')
+
+	// #endregion
+
 	// #region 0.7.19 -> 0.9 conversion
 
 	event.add('c:hidden_from_recipe_viewers', 'treetap:tap')

--- a/kubejs/server_scripts/tfg/tags.js
+++ b/kubejs/server_scripts/tfg/tags.js
@@ -130,8 +130,8 @@ const registerTFGItemTags = (event) => {
 	// #endregion
 
 	// Use either cast or wrought iron
-	event.add('forge:double_iron_ingots', 'tfc:metal/double_ingot/cast_iron')
-	event.add('forge:double_iron_ingots', 'gtceu:wrought_iron_double_ingot')
+	event.add('forge:double_iron_ingots', '#forge:double_ingots/iron')
+	event.add('forge:double_iron_ingots', '#forge:double_ingots/wrought_iron')
 
 	// #endregion
 

--- a/kubejs/server_scripts/vintage_improvements/recipes.js
+++ b/kubejs/server_scripts/vintage_improvements/recipes.js
@@ -84,7 +84,7 @@ function registerVintageImprovementsRecipes(event) {
 	], {
 		A: '#forge:frames/bronze',
 		B: '#tfg:hardwood',
-		C: '#forge:double_ingots/iron',
+		C: '#forge:double_iron_ingots',
 		D: 'greate:andesite_alloy_cogwheel',
 		E: '#minecraft:planks',
 		F: '#forge:tools/hammers'
@@ -97,7 +97,7 @@ function registerVintageImprovementsRecipes(event) {
 	], {
 		A: '#forge:frames/black_bronze',
 		B: '#tfg:hardwood',
-		C: '#forge:double_ingots/iron',
+		C: '#forge:double_iron_ingots',
 		D: 'greate:andesite_alloy_cogwheel',
 		E: '#minecraft:planks',
 		F: '#forge:tools/hammers'
@@ -110,7 +110,7 @@ function registerVintageImprovementsRecipes(event) {
 	], {
 		A: '#forge:frames/bismuth_bronze',
 		B: '#tfg:hardwood',
-		C: '#forge:double_ingots/iron',
+		C: '#forge:double_iron_ingots',
 		D: 'greate:andesite_alloy_cogwheel',
 		E: '#minecraft:planks',
 		F: '#forge:tools/hammers'


### PR DESCRIPTION
## What is the new behavior?
Added alternative recipes for wooden crates, copper diving boots and the helve hammer that use wrought iron instead of cast iron.

## Implementation Details
Added a new tag that includes cast/wrought iron double ingots (this is used for the helve hammer recipes) and made use of the create deco tag for the copper diving boots.

## Additional Information
This change makes it so that wrought iron can be used as well as cast iron for these early game recipes.