### PR TITLE
Large water wheel SU generation to match SU value of steel tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [Unreleased]
 ### Changes
+- Increase Large Water Wheel to 128SU generation to match previous buff to steel tier shafts (Oosyrag)
 - Rebalanced the Large Boilers so now they consume WAY less fuel, so lava is no longer basically mandatory - see [here](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/977) for the full math (Oosyrag)
 - Greenhouse ports and sprinklers now work directly with gregtech pipes (Thomasx0)
 - Added recipes for stainless steel greenhouse parts (Pyritie)

--- a/defaultconfigs/create-server.toml
+++ b/defaultconfigs/create-server.toml
@@ -302,7 +302,7 @@
 				hand_crank = 2.0
 				steam_engine = 16.0
 				creative_motor = 16384.0
-				large_water_wheel = 16.0
+				large_water_wheel = 32.0
 				water_wheel = 4.0
 				windmill_bearing = 32.0
 

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1408,12 +1408,13 @@ const registerCreateRecipes = (event) => {
 	}).id('create:shaped/water_wheel')
 
 	event.shaped('create:large_water_wheel', [
-		'AAA',
+		'CAC',
 		'ABA',
-		'AAA'
+		'CAC'
 	], {
 		A: 'gtceu:treated_wood_planks',
-		B: 'create:water_wheel'
+		B: 'create:water_wheel',
+		C: 'gtceu:steel_rod'
 	}).id('create:shaped/large_water_wheel')
 
 	// #endregion


### PR DESCRIPTION
## What is the new behavior?

Large water wheel SU generation 64SU to 128SU, to match the previous balance update for steel tier from 64SU to128SU.
Large water wheel recipe changed to include 4 steel rods, to make it obviously steel tier, along with a small cost increase for the performance increase.

## Implementation Details

Double water wheels everywhere to take advantage of the steel shaft limits look ugly and should probably be unecessary.

Small waterwheels happened to already be 32SU before (where basic/bronze tier SU was 16, now 32 to match). This update makes large water wheels match the steel tier (before the shaft SU increase large water wheel were matching steel tier at 64SU, but now underpowered when those increased to 128SU).

If people still want to stack 4 waterwheels to use with aluminum shafts at 512SU, they still can but hopefully steam engines (and windmills?) can be made more suitable for further tiers

Alternative solution - Leave the existing one at 64SU and let people [double up](https://discord.com/channels/400913133620822016/1167131539046400010/1371339550160326686) if they want, and add a new recipe for a reinforced large water wheel that costs steel for 128SU generation.
