### PR TITLE
Some recipe changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 ### Changes
+- Renamed Salt (powder) to Table Salt (Oosyrag)
+- Changed wooden tongs recipe from shapeless to shaped (Oosyrag)
+- Added crafting recipe for tin jar lids (Oosyrag)
 - Rebalanced the Large Boilers so now they consume WAY less fuel, so lava is no longer basically mandatory - see [here](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/977) for the full math (Oosyrag)
 - Greenhouse ports and sprinklers now work directly with gregtech pipes (Thomasx0)
 - Added recipes for stainless steel greenhouse parts (Pyritie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 ## [Unreleased]
 ### Changes
-- Renamed Salt (powder) to Table Salt (Oosyrag)
 - Changed wooden tongs recipe from shapeless to shaped (Oosyrag)
 - Added crafting recipe for tin jar lids (Oosyrag)
 - Rebalanced the Large Boilers so now they consume WAY less fuel, so lava is no longer basically mandatory - see [here](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/977) for the full math (Oosyrag)

--- a/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/en_us/entries/getting_started/finding_ores.json
@@ -58,7 +58,7 @@
     {
       "type": "patchouli:crafting",
       "recipe": "tfchotornot:crafting/tongs/wood",
-      "text": "Careful, the vessel will be hot! Craft $(thing)Wooden Tongs$() with two sticks and a knife and hold them in your off hand to handle the hot vessel safely. (This is a $(thing)Shapeless Recipe$(), you can make it in your inventory crafting grid)"
+      "text": "Careful, the vessel will be hot! Craft $(thing)Wooden Tongs$() with two sticks and a knife and hold them in your off hand to handle the hot vessel safely."
     },
     {
       "type": "patchouli:image",

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -90,9 +90,4 @@ const registerTooltips = (event) =>
 	event.addAdvanced(['#tfc:fired_vessels'], (item, advanced, text) => {
 		text.add(1, text.of('§cMax: 3024mB'))
 	})
-
-	// Rename Salt to Table Salt
-	ClientEvents.lang("en_us", e => {
-		e.renameItem('tfc:powder/salt', 'Table Salt')
-	})
 }

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -90,4 +90,9 @@ const registerTooltips = (event) =>
 	event.addAdvanced(['#tfc:fired_vessels'], (item, advanced, text) => {
 		text.add(1, text.of('§cMax: 3024mB'))
 	})
+
+	// Rename Salt to Table Salt
+	ClientEvents.lang("en_us", e => {
+		e.renameItem('tfc:powder/salt', 'Table Salt')
+	})
 }

--- a/kubejs/server_scripts/hotornot/recipes.js
+++ b/kubejs/server_scripts/hotornot/recipes.js
@@ -1,5 +1,14 @@
 // priority: 0
 
 const registerHotOrNotRecipes = (event) => {
-    
+
+    event.shaped('tfchotornot:tongs/wood', [
+		'AB ',
+		'B  ',
+		'   '
+	], {
+		A: '#forge:tools/knives',
+		B: '#forge:rods/wooden'
+	}).id('tfchotornot:crafting/tongs/wood')
+
 }

--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -329,7 +329,8 @@ const registerTFCRecipes = (event) => {
 
 	event.shapeless('8x tfc:jar_lid', [
 		'gtceu:tin_ingot',
-		'#forge:tools/hammers'
+		'#forge:tools/hammers',
+		'#forge:tools/saws'
 	]).id('tfc:shapeless/jar_lid')
 
 }

--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -324,4 +324,12 @@ const registerTFCRecipes = (event) => {
 			.circuit(6)
 			.EUt(GTValues.VA[GTValues.ULV])
 	});
+
+	// Jar lids
+
+	event.shapeless('8x tfc:jar_lid', [
+		'gtceu:tin_ingot',
+		'#forge:tools/hammers'
+	]).id('tfc:shapeless/jar_lid')
+
 }


### PR DESCRIPTION
## What is the new behavior?

Changed wooden tongs recipe from shapeless to shaped - People seemed to commonly get confused about how to cast their first metal tools now that vessels with molten metal are too hot to hold, thinking they need a workbench 3x3 crafting grid to make wooden tongs and can't get one without casting a metal saw.

Added a crafting recipe for jar lids, since working tin on an anvil is rather difficult, and jar lids are consumables. Crafting recipe results in half yield (8x) vs forging (16x).

## Implementation Details

~~Salt (dust) and Salt (powder) have the same name. Changed Salt (powder) to Table Salt~~ This implementation didn't seem to work. In draft until I resolve or remove. (Or if someone knows how to do this right please let me know!)

Tested in game for above recipes, they work fine. 
