### PR TITLE
Updated carryon-common.toml for afc

### DIFF
--- a/config/carryon-common.toml
+++ b/config/carryon-common.toml
@@ -59,7 +59,7 @@
 	#Entities that CAN be picked up (useWhitelistEntities must be true)
 	allowedEntities = ["tfc:turkey", "tfc:dog", "tfc:isopod", "tfc:lobster", "tfc:frog", "tfc:penguin", "tfc:turtle", "tfc:horseshoe_crab", "tfc:crayfish", "tfc:grouse", "tfc:pheasant", "tfc:peafowl", "tfc:rat", "tfc:cat", "tfc:chicken", "tfc:duck", "tfc:quail", "tfc:rabbit"]
 	#Blocks that CAN be picked up (useWhitelistBlocks must be true)
-	allowedBlocks = ["framedblocks:framed_chest", "tfc:wood/chest/*", "tfc:wood/trapped_chest/*", "#forge:chests/wooden"]
+	allowedBlocks = ["framedblocks:framed_chest", "tfc:wood/chest/*", "tfc:wood/trapped_chest/*", "afc:wood/chest/*", "afc:wood/trapped_chest/*", "#forge:chests/wooden"]
 	#Entities that CAN have other entities stacked on top of them (useWhitelistStacking must be true)
 	allowedStacking = []
 


### PR DESCRIPTION
## What is the new behavior?
Added the afc chests to Carry On's whitelisted blocks.

## Implementation Details
Explicitly added the arborafirmacraft chests to the whitelist.

## Outcome
The afc chests can now be picked up by players just like the tfc ones can.

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**

noble_was_taken