### PR TITLE
disallow inventory tweaks' sort inventory function in tfc screens

### DIFF
--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -129,6 +129,10 @@
 		containerClass = "gripe._90.megacells.menu.MEGAInterfaceMenu"
 		sortRange = ""
 
+	[[sorting.containerOverrides]]
+		containerClass = "net.dries007.tfc.client.screen.*"
+		sortRange = ""
+
 #Tweaks
 [tweaks]
 	#Enable auto-refill


### PR DESCRIPTION
## What is the new behavior?
there's a silly bug where if you hit the 'sort inventory' key in the crucible, you get stacks of ingots where there should only be single ingots. this should be prevented

## Implementation Details
added all of the tfc screens with a wildcard glob, affected screens (some of which aren't actually inventories, but that shouldn't matter) are found at:
https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.20.x/src/main/java/net/dries007/tfc/compat/jei/JEIIntegration.java#L43-L53

## Outcome
disallow inventory tweaks' sort inventory function in tfc screens

## Potential Compatibility Issues
it is somewhat possible a tfc addon might put their screens in the same space, if necessary the match can be made more specific.

scenarios tested:
you CANNOT use a hotkey to sort in vessel, large vessel, or crucible.

untested: it should also prevent sorting in the cooking inventories (guaranteed harmless either way)

you CAN sort a terrafirmacraft chest.
you CAN sort the inventory of a compartment in a firma civ boat.
you CAN sort your PERSONAL inventory while you have a tfc inventory screen open by mousing over your personal inventory when hitting the hotkey.

discord: esotericist