### PR TITLE
Tin hammering recipe

### DIFF
--- a/kubejs/server_scripts/vintage_improvements/recipes.js
+++ b/kubejs/server_scripts/vintage_improvements/recipes.js
@@ -197,7 +197,8 @@ function registerVintageImprovementsRecipes(event) {
 		{ material: GTMaterials.Gold, blows: STARTING_BLOWS },
 		{ material: GTMaterials.Bismuth, blows: STARTING_BLOWS },
 		{ material: GTMaterials.RoseGold, blows: STARTING_BLOWS },
-		{ material: GTMaterials.SterlingSilver, blows: STARTING_BLOWS }
+		{ material: GTMaterials.SterlingSilver, blows: STARTING_BLOWS },
+		{ material: GTMaterials.Tin, blows: STARTING_BLOWS }
 	]
 
 	let HAMMERING_ITEMS = [
@@ -413,7 +414,7 @@ function registerVintageImprovementsRecipes(event) {
 				results: [ChemicalHelper.get(TFGTagPrefix.ingotDouble, material, 1)],
 				processingTime: material.getMass() * 6 * global.VINTAGE_IMPROVEMENTS_DURATION_MULTIPLIER
 			}).id(`tfg:vi/pressurizing/${material.getName()}_double_ingot`)
-			
+
 			const plateItem = ChemicalHelper.get(TagPrefix.plate, material, 1);
 
 			event.custom({
@@ -511,9 +512,9 @@ function registerVintageImprovementsRecipes(event) {
 
 			event.custom({
 				type: 'vintageimprovements:curving',
-				ingredients: [ input ],
+				ingredients: [input],
 				itemAsHead: r.inputs.item[1].content.ingredient.item,
-				results: [ output ],
+				results: [output],
 				processingTime: r.duration * global.VINTAGE_IMPROVEMENTS_DURATION_MULTIPLIER
 			}).id(`tfg:vi/curving/${recipe.getId().split(':')[1]}`)
 		}
@@ -604,10 +605,10 @@ function registerVintageImprovementsRecipes(event) {
 	event.custom({
 		type: 'vintageimprovements:vacuumizing',
 		ingredients: [{ fluid: 'tfg:vulcanized_latex', amount: 250 }],
-		results: [{ item: 'gtceu:raw_rubber_dust'}],
+		results: [{ item: 'gtceu:raw_rubber_dust' }],
 		processingTime: 120
 	}).id('tfg:vi/vacuumizing/vulcanized_latex_to_raw_rubber')
-	
+
 	// #endregion
 }
 


### PR DESCRIPTION
## What is the new behavior?
Helve hammer now create tin plate from tin double ingots

## Implementation Details
I just added missing tin recipe for hammering

## Outcome
Fixes #1064

## Additional Information
Recipe screenshot:
![image](https://github.com/user-attachments/assets/c3ec696c-f659-46ef-a043-c75e81c889a5)

## Potential Compatibility Issues
Not compatible with tin double ingots from TerraFirmaCraft, only with GT double ingots, tho must be fine with game

discord: ownog

P.S vscode add some prettienes to json formatting, I didn't changed it, because i think it's for greater good. Is it okay or i must revert it?
