### PR TITLE
Reduce rarity for graphite veins

### DIFF
--- a/kubejs/data/tfg/worldgen/configured_feature/earth/vein/normal_graphite.json
+++ b/kubejs/data/tfg/worldgen/configured_feature/earth/vein/normal_graphite.json
@@ -4,391 +4,170 @@
   "config": {
     "height": 6,
     "size": 16,
-    "rarity": 80,
+    "rarity": 60,
     "density": 0.4,
     "min_y": -64,
     "max_y": -16,
     "random_name": "normal_graphite",
     "blocks": [
       {
-        "replace": [
-          "tfc:rock/raw/gabbro"
-        ],
+        "replace": [ "tfc:rock/raw/gabbro" ],
         "with": [
-          {
-            "block": "gtceu:gabbro_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:gabbro_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:gabbro_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:gabbro_graphite_ore", "weight": 45 },
+          { "block": "gtceu:gabbro_diamond_ore", "weight": 25 },
+          { "block": "gtceu:gabbro_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/granite"
-        ],
+        "replace": [ "tfc:rock/raw/granite" ],
         "with": [
-          {
-            "block": "gtceu:granite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:granite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:granite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:granite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:granite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:granite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/diorite"
-        ],
+        "replace": [ "tfc:rock/raw/diorite" ],
         "with": [
-          {
-            "block": "gtceu:diorite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:diorite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:diorite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:diorite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:diorite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:diorite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/schist"
-        ],
+        "replace": [ "tfc:rock/raw/schist" ],
         "with": [
-          {
-            "block": "gtceu:schist_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:schist_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:schist_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:schist_graphite_ore", "weight": 45 },
+          { "block": "gtceu:schist_diamond_ore", "weight": 25 },
+          { "block": "gtceu:schist_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/gneiss"
-        ],
+        "replace": [ "tfc:rock/raw/gneiss" ],
         "with": [
-          {
-            "block": "gtceu:gneiss_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:gneiss_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:gneiss_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:gneiss_graphite_ore", "weight": 45 },
+          { "block": "gtceu:gneiss_diamond_ore", "weight": 25 },
+          { "block": "gtceu:gneiss_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/quartzite"
-        ],
+        "replace": [ "tfc:rock/raw/quartzite" ],
         "with": [
-          {
-            "block": "gtceu:quartzite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:quartzite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:quartzite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:quartzite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:quartzite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:quartzite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/phyllite"
-        ],
+        "replace": [ "tfc:rock/raw/phyllite" ],
         "with": [
-          {
-            "block": "gtceu:phyllite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:phyllite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:phyllite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:phyllite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:phyllite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:phyllite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/slate"
-        ],
+        "replace": [ "tfc:rock/raw/slate" ],
         "with": [
-          {
-            "block": "gtceu:slate_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:slate_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:slate_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:slate_graphite_ore", "weight": 45 },
+          { "block": "gtceu:slate_diamond_ore", "weight": 25 },
+          { "block": "gtceu:slate_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/marble"
-        ],
+        "replace": [ "tfc:rock/raw/marble" ],
         "with": [
-          {
-            "block": "gtceu:marble_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:marble_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:marble_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:marble_graphite_ore", "weight": 45 },
+          { "block": "gtceu:marble_diamond_ore", "weight": 25 },
+          { "block": "gtceu:marble_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/dacite"
-        ],
+        "replace": [ "tfc:rock/raw/dacite" ],
         "with": [
-          {
-            "block": "gtceu:dacite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:dacite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:dacite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:dacite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:dacite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:dacite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/rhyolite"
-        ],
+        "replace": [ "tfc:rock/raw/rhyolite" ],
         "with": [
-          {
-            "block": "gtceu:rhyolite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:rhyolite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:rhyolite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:rhyolite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:rhyolite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:rhyolite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/andesite"
-        ],
+        "replace": [ "tfc:rock/raw/andesite" ],
         "with": [
-          {
-            "block": "gtceu:andesite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:andesite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:andesite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:andesite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:andesite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:andesite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "minecraft:basalt",
-          "tfc:rock/raw/basalt"
-        ],
+        "replace": [ "minecraft:basalt", "tfc:rock/raw/basalt" ],
         "with": [
-          {
-            "block": "gtceu:basalt_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:basalt_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:basalt_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:basalt_graphite_ore", "weight": 45 },
+          { "block": "gtceu:basalt_diamond_ore", "weight": 25 },
+          { "block": "gtceu:basalt_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/shale"
-        ],
+        "replace": [ "tfc:rock/raw/shale" ],
         "with": [
-          {
-            "block": "gtceu:shale_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:shale_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:shale_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:shale_graphite_ore", "weight": 45 },
+          { "block": "gtceu:shale_diamond_ore", "weight": 25 },
+          { "block": "gtceu:shale_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/claystone"
-        ],
+        "replace": [ "tfc:rock/raw/claystone" ],
         "with": [
-          {
-            "block": "gtceu:claystone_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:claystone_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:claystone_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:claystone_graphite_ore", "weight": 45 },
+          { "block": "gtceu:claystone_diamond_ore", "weight": 25 },
+          { "block": "gtceu:claystone_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/limestone"
-        ],
+        "replace": [ "tfc:rock/raw/limestone" ],
         "with": [
-          {
-            "block": "gtceu:limestone_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:limestone_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:limestone_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:limestone_graphite_ore", "weight": 45 },
+          { "block": "gtceu:limestone_diamond_ore", "weight": 25 },
+          { "block": "gtceu:limestone_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/conglomerate"
-        ],
+        "replace": [ "tfc:rock/raw/conglomerate" ],
         "with": [
-          {
-            "block": "gtceu:conglomerate_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:conglomerate_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:conglomerate_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:conglomerate_graphite_ore", "weight": 45 },
+          { "block": "gtceu:conglomerate_diamond_ore", "weight": 25 },
+          { "block": "gtceu:conglomerate_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/dolomite"
-        ],
+        "replace": [ "tfc:rock/raw/dolomite" ],
         "with": [
-          {
-            "block": "gtceu:dolomite_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:dolomite_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:dolomite_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:dolomite_graphite_ore", "weight": 45 },
+          { "block": "gtceu:dolomite_diamond_ore", "weight": 25 },
+          { "block": "gtceu:dolomite_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/chert"
-        ],
+        "replace": [ "tfc:rock/raw/chert" ],
         "with": [
-          {
-            "block": "gtceu:chert_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:chert_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:chert_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:chert_graphite_ore", "weight": 45 },
+          { "block": "gtceu:chert_diamond_ore", "weight": 25 },
+          { "block": "gtceu:chert_coal_ore", "weight": 30 }
         ]
       },
       {
-        "replace": [
-          "tfc:rock/raw/chalk"
-        ],
+        "replace": [ "tfc:rock/raw/chalk" ],
         "with": [
-          {
-            "block": "gtceu:chalk_graphite_ore",
-            "weight": 45
-          },
-          {
-            "block": "gtceu:chalk_diamond_ore",
-            "weight": 25
-          },
-          {
-            "block": "gtceu:chalk_coal_ore",
-            "weight": 30
-          }
+          { "block": "gtceu:chalk_graphite_ore", "weight": 45 },
+          { "block": "gtceu:chalk_diamond_ore", "weight": 25 },
+          { "block": "gtceu:chalk_coal_ore", "weight": 30 }
         ]
       }
     ],
@@ -398,18 +177,9 @@
       "underground_rarity": 30,
       "underground_count": 400,
       "blocks": [
-        {
-          "block": "gtceu:graphite_indicator",
-          "weight": 45
-        },
-        {
-          "block": "gtceu:coal_indicator",
-          "weight": 30
-        },
-        {
-          "block": "gtceu:diamond_bud_indicator",
-          "weight": 25
-        }
+        { "block": "gtceu:graphite_indicator", "weight": 45 },
+        { "block": "gtceu:coal_indicator", "weight": 30 },
+        { "block": "gtceu:diamond_bud_indicator", "weight": 25 }
       ]
     }
   }


### PR DESCRIPTION
## What is the new behavior?
Decreases overworld graphite rarity, so that finding graphite with a prospectors pick is more feasible.

## Implementation Details
Change graphite vein rarity from 80 to 60. Previously it was pretty common to not see any graphite at all within range of the big prospector.

## Outcome
Graphite more common, but there are still some areas where its possible to not have any within range of prospector. 
Screenshots of new world at rarity 60:
![2025-05-26_13 24 19](https://github.com/user-attachments/assets/32696f6f-87f0-4754-86d6-6641cf559a2a)
![2025-05-26_13 19 22](https://github.com/user-attachments/assets/63e8b36f-c0d3-43db-a029-3de93fe90dc3)
![2025-05-26_13 19 45](https://github.com/user-attachments/assets/3c9d6a5b-3a30-4a69-82c4-1abcdd28ebe6)
![2025-05-26_13 20 14](https://github.com/user-attachments/assets/e430a9ec-b73a-4db1-9c53-26422e40f7f8)
![2025-05-26_13 20 37](https://github.com/user-attachments/assets/1da772b1-0b45-4c6d-972f-24b6d25f4e3a)
![2025-05-26_13 21 14](https://github.com/user-attachments/assets/6c174542-3a43-42a6-998f-722675a770d9)
![2025-05-26_13 22 41](https://github.com/user-attachments/assets/31734f62-e6e9-4481-9503-b62aff5dad7a)


## Additional Information
Not sure what's going on with my VSC autoformatting... hope that's ok.