### PR TITLE
Harmonize jars size

### DIFF
--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -209,6 +209,9 @@ const registerTFCItemSize = (event) => {
     event.itemSize('tfg:fishing_net/magnalium', 'large', 'medium', 'magnalium_fishing_net')
 
     event.itemSize('#tfc:ore_pieces', 'very_small', 'very_light', 'tfc_ores')
+	
+    event.itemSize('#tfc:foods/sealed_preserves', 'tiny', 'heavy')
+    event.itemSize('#tfc:foods/preserves', 'tiny', 'heavy')
 
 }
 //#endregion

--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -212,6 +212,10 @@ const registerTFCItemSize = (event) => {
 	
     event.itemSize('#tfc:foods/sealed_preserves', 'tiny', 'heavy')
     event.itemSize('#tfc:foods/preserves', 'tiny', 'heavy')
+    event.itemSize('firmalife:jar/honey', 'tiny', 'heavy')
+    event.itemSize('firmalife:jar/compost', 'tiny', 'heavy')
+    event.itemSize('firmalife:jar/rotten_compost', 'tiny', 'heavy')
+    event.itemSize('firmalife:jar/guano', 'tiny', 'heavy')
 
 }
 //#endregion


### PR DESCRIPTION
## What is the new behavior?
Full jars are the same size as empty jars.
The only effect I see is when placing them with "v", full jars are consistent with empty jars. (take 1/4 of a block, not a full block)

## Implementation Details
Added some  `event.itemSize()` in `\kubejs\server_scripts\tfc\data.js`

Alternative I though :
- changing only the tfc's jars in TFC's folder, and changing the firmalife one's in firmalife folder. Firmalife had no data.js
- changing the weight from *Heavy* to *Medium*.

I put this PR as a draft because I do not understand the last parameter of the `itemSize()` function.
If someone can tell me...
And also because I would want to figure out how to stack more than 4 full jars in shelfs.

## Outcome
Full jars are the same size as empty jars.

## Additional Information

It don't change how many full jars we can put in shelfs (only 4).
It don't change how many jars we place with right click (4).
It don't change any weight because I dont want to break balance.

Before : 
![image](https://github.com/user-attachments/assets/311f2aa8-cbfb-4124-971d-91bb65b707c0)
After : 
![image](https://github.com/user-attachments/assets/2ec8361f-c421-410e-a2e5-11a07dc283a6)

I tried this pull request after this discord thread : [Item Size and Weight Deconfliction](https://discord.com/channels/400913133620822016/1376606408199372960)

## Potential Compatibility Issues
This error show up about a file I did not touch `Failed to create recipe for type 'tfc:sewing': ItemStack 'result' can't be empty!`
![image](https://github.com/user-attachments/assets/38a81b29-440c-4d15-91f5-7d6c28f7a0b5)

Because it don't seem related by the items touched nor the files, I felt free to PR anyway.

Zeropol