### PR TITLE
Vulcanized latex using Vacuum Chamber

### DIFF
--- a/kubejs/server_scripts/vintage_improvements/recipes.js
+++ b/kubejs/server_scripts/vintage_improvements/recipes.js
@@ -601,6 +601,14 @@ function registerVintageImprovementsRecipes(event) {
 		processingTime: 40
 	}).id('tfg:vi/vacuumizing/latex_from_rubber_plants')
 
+	event.custom({
+		type: 'vintageimprovements:vacuumizing',
+		ingredients: [{ item: 'tfc:powder/sulfur' }, { fluid: 'tfg:latex', amount: 1000 }],
+		results: [{ fluid: 'tfg:vulcanized_latex', amount: 1000 }],
+		heatRequirement: "heated",
+		processingTime: 50
+	}).id('tfg:vi/vacuumizing/vulcanized_latex_from_sulfur')
+
 	// Vulc. latex to raw rubber pulp
 	event.custom({
 		type: 'vintageimprovements:vacuumizing',


### PR DESCRIPTION
## What is the new behavior?

adds a recipe to craft vulcanized latex using the vacuum chamber

## Implementation Details

the recipe needs to be heated so its similar as if using a vat to craft vulcanized latex

## Outcome

Now its possible to use the vacuum chamber to craft vulcanized latex

## Potential Compatibility Issues

One issue or feature is that when it finishes making vulcanized latex it also starts making raw rubber pulp
if there are still some sulfur powder in the basin

discord
fernandim_modelador

