### PR TITLE
TFC sugar recipes use tfg:sugars tag and kaolin dupe fix

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -190,8 +190,8 @@ const registerTFCRecipes = (event) => {
 		.EUt(GTValues.VA[GTValues.ULV])
 
 	event.recipes.gtceu.alloy_smelter('tfg:oops_i_smelted_all_my_kaolin')
-		.itemInputs('5x minecraft:clay_ball', 'tfc:powder/kaolinite')
-		.itemOutputs('5x tfc:kaolin_clay')
+		.itemInputs('minecraft:clay_ball', 'tfc:powder/kaolinite')
+		.itemOutputs('tfc:kaolin_clay')
 		.duration(600)
 		.EUt(GTValues.VA[GTValues.ULV])
 
@@ -333,4 +333,5 @@ const registerTFCRecipes = (event) => {
 		'#forge:tools/saws'
 	]).id('tfc:shapeless/jar_lid')
 
+	event.replaceInput({ mod: 'tfc' }, 'minecraft:sugar', '#tfg:sugars')
 }


### PR DESCRIPTION
## What is the new behavior?
TFC recipes that use sugar now use the tfg:sugars tag which includes maple and birch sugar, before some recipes had to be just regular sugar. It was also found on Discord that the alloy smelter could be used to duplicate kaolin clay https://discord.com/channels/400913133620822016/1167131539046400010/1377614581916110949, this recipe was adjusted to prevent that.

## Implementation Details
Added a replaceInput event for tfc sugar recipes. Changed the kaolin clay alloy smelter recipe to be 1 clay ball + 1 kaolinite powder = 1 kaolin clay (instead of 5 clay and 1 powder for 5 kaolin clay).

## Outcome
TFC recipes using sugar (such as rum) can now be made with any sugar. Prevented duplication of kaolin clay from alloy smelting it with clay and re-smelting it for powder.

Discord: spicy_noodle5