### PR TITLE
add the create toolbox to the list of unsortable inventories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added Wine utensils recipes for GT (#1111) @JeanRdS
 - Fixed kaolin clay duping (#1099) @SpicyNoodle5
 - Fixed TFC sugar recipes so they can now use any sugar (#1099) @SpicyNoodle5
+- add the create toolbox to the list of unsortable inventories (#1120) @esotericist
 
 ## [0.9.9] - 30.05.2025
 ### Changes

--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -133,6 +133,10 @@
 		containerClass = "net.dries007.tfc.client.screen.*"
 		sortRange = ""
 
+	[[sorting.containerOverrides]]
+		containerClass = "com.simibubi.create.content.equipment.toolbox.ToolboxMenu"
+		sortRange = ""
+
 #Tweaks
 [tweaks]
 	#Enable auto-refill


### PR DESCRIPTION
## What is the new behavior?

#1115 

## Implementation Details

same as #1045, add the appropriate gui class to inventory tweaks rewhozited, so that it doesn't render the sort button, or allow the manual sort hotkey

## Outcome

fixes #1115 

## Potential Compatibility Issues

if it turns out there's another create ui with inventory slots, it'll need to be handled separately, this was a targeted fix to only the toolbox unlike when i said 'no u' to all of tfc's non-chest guis.