### PR TITLE
Fix Scaffolding Frame conflict

### DIFF
--- a/kubejs/server_scripts/tfg/recipes.miscellaneous.js
+++ b/kubejs/server_scripts/tfg/recipes.miscellaneous.js
@@ -141,6 +141,7 @@ function registerTFGMiscellaneousRecipes(event) {
 		.itemInputs('4x #forge:rods/wood', '#forge:cloth')
 		.itemOutputs('tfg:scaffolding_frame')
 		.duration(10)
+		.circuit(5)
 		.EUt(GTValues.VA[GTValues.ULV]);
 
 	//Airship Hull


### PR DESCRIPTION



## What is the new behavior?
This adds a circuit for the Scaffolding Frame recipe

## Outcome
This will fix the conflict between Scaffolding Frame and Painting recipes

![image](https://github.com/user-attachments/assets/98423f14-ec12-4d0f-8fce-0f3565c30b02)
