### PR TITLE
Migmatite conflict fix

### DIFF
--- a/kubejs/server_scripts/tfg/recipes.rocks.js
+++ b/kubejs/server_scripts/tfg/recipes.rocks.js
@@ -70,7 +70,7 @@ function registerTFGRockRecipes(event) {
 		event.recipes.gtceu.laser_engraver(`${x.raw}_to_${x.polished}`.replace(/:/g, '_'))
 			.itemInputs(x.raw)
 			.itemOutputs(x.polished)
-			.notConsumable('tfc:lens')
+			.notConsumable('gtceu:glass_tube')
 			.duration(30)
 			.EUt(GTValues.VA[GTValues.ULV])
 


### PR DESCRIPTION

## What is the new behavior?
Polished rock recipes will use a glass tube instead of lens in the Laser Engraver machine

## Outcome
This will fix the Polished-Cut Migmatite conflict. Tbh I can hardly call this a good solution, but with Stonecutter coming back, this might even be meaningless
![image](https://github.com/user-attachments/assets/0a108d9a-a4ff-4f7e-87d6-22c01480cede)
