### PR TITLE
ABS glowstone recipe

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1076,6 +1076,16 @@ const registerGTCEURecipes = (event) => {
 		.EUt(GTValues.VA[GTValues.ULV])
 
 	//#endregion 
+	
+	//#region glowstone
+	event.recipes.gtceu.alloy_blast_smelter('abs:liquid_glowstone')
+        	.itemInputs('#forge:dusts/gold', '#forge:dusts/redstone', '#forge:dusts/sulfur')
+		.outputFluids(Fluid.of('gtceu:glowstone', 288))
+		.duration(20*60/1.3)
+		.EUt(GTValues.VA[GTValues.LV])
+		.blastFurnaceTemp(1064)
+	//#endregion
+	
 
     //#region Large boilers fuel rebalance
 

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1084,6 +1084,7 @@ const registerGTCEURecipes = (event) => {
 		.duration(20*60/1.3)
 		.EUt(GTValues.VA[GTValues.LV])
 		.blastFurnaceTemp(1064)
+		.circuit(9)
 	//#endregion
 	
 


### PR DESCRIPTION
## What is the new behavior?
 - Glowstone abs recipe
 - Gives an direct way to get liquid glowstone (used in nano cpu wafers and decoration)
 
## Outcome
ABS glowstone recipe