### PR TITLE
Small fixes for many different recipes

### DIFF
--- a/kubejs/server_scripts/ad_astra/recipes.js
+++ b/kubejs/server_scripts/ad_astra/recipes.js
@@ -25,6 +25,7 @@ const registerAdAstraRecipes = (event) => {
 		.inputFluids(Fluid.of('gtceu:polyethylene', 144 * 16))
 		.itemOutputs('ad_astra:rocket_nose_cone')
 		.duration(1200)
+		.circuit(2)
 		.EUt(480)
 
 
@@ -40,6 +41,7 @@ const registerAdAstraRecipes = (event) => {
 		.inputFluids(Fluid.of('gtceu:red_steel', 144))
 		.itemOutputs('9x #forge:dusts/rocket_alloy_t1')
 		.duration(580)
+		.circuit(2)
 		.EUt(480)
 
 	event.recipes.gtceu.chemical_bath('tfg:rocket_alloy_cool_down_water')
@@ -60,6 +62,7 @@ const registerAdAstraRecipes = (event) => {
 		.itemInputs('#forge:plates/rocket_alloy_t1', '#forge:double_plates/stainless_steel')
 		.itemOutputs('ad_astra:rocket_fin')
 		.duration(150)
+		.circuit(2)
 		.EUt(GTValues.VA[GTValues.HV])
 
 
@@ -73,6 +76,7 @@ const registerAdAstraRecipes = (event) => {
 		.inputFluids(Fluid.of('gtceu:blue_steel', 144 * 8))
 		.itemOutputs('ad_astra:steel_engine')
 		.duration(600)
+		.circuit(2)
 		.EUt(GTValues.VA[GTValues.HV])
 
 	event.recipes.gtceu.assembler('ad_astra:assembler_tier_1_rocket')
@@ -86,6 +90,7 @@ const registerAdAstraRecipes = (event) => {
 		.inputFluids(Fluid.of('gtceu:silicon', 144 * 16))
 		.itemOutputs('ad_astra:tier_1_rocket')
 		.duration(1200)
+		.circuit(2)
 		.EUt(GTValues.VA[GTValues.HV])
 
 	//#endregion

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1194,9 +1194,9 @@ const registerGTCEURecipes = (event) => {
 	generateMixerRecipe(event, ['gtceu:tiny_nether_quartz_dust', '8x gtceu:tiny_redstone_dust'], [], 'gtceu:rose_quartz_dust', 2, [], 20, 60, 64, 'tiny_rose_quartz_dust_mixing')
 
 	event.recipes.gtceu.autoclave("autoclave_dust_rose_quartz_ice")
-		.itemInputs('#forge:gems/rose_quartz')
+		.itemInputs('#forge:dusts/rose_quartz')
 		.inputFluids(Fluid.of("gtceu:ice", 144))
-		.itemOutputs("gtceu:rose_quartz_gem")
+		.itemOutputs("#forge:gems/rose_quartz")
 		.duration(2000)
 		.EUt(120)
 

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1194,7 +1194,7 @@ const registerGTCEURecipes = (event) => {
 	generateMixerRecipe(event, ['gtceu:tiny_nether_quartz_dust', '8x gtceu:tiny_redstone_dust'], [], 'gtceu:rose_quartz_dust', 2, [], 20, 60, 64, 'tiny_rose_quartz_dust_mixing')
 
 	event.recipes.gtceu.autoclave("autoclave_dust_rose_quartz_ice")
-		.itemInputs("gtceu:rose_quartz_dust")
+		.itemInputs('#forge:gems/rose_quartz')
 		.inputFluids(Fluid.of("gtceu:ice", 144))
 		.itemOutputs("gtceu:rose_quartz_gem")
 		.duration(2000)

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1040,6 +1040,15 @@ const registerGTCEURecipes = (event) => {
 
 	//#endregion
 
+	// Fix Snow in Compressor
+
+	event.remove({ id: 'gtceu:compressor/snowballs_to_snow' })
+	event.recipes.gtceu.compressor('gtceu:compressor/snowballs_to_snow_fixed')
+		.itemInputs('8x minecraft:snowball')
+		.itemOutputs('minecraft:snow_block')
+		.duration(20*10)
+		.EUt(2)
+
 	//#region Changing tiers of decomposition recipes
 
 	event.recipes.gtceu.electrolyzer('gtceu:decomposition_electrolyzing_clay')

--- a/kubejs/server_scripts/gregtech/recipes.removes.js
+++ b/kubejs/server_scripts/gregtech/recipes.removes.js
@@ -666,6 +666,15 @@ function removeGTCEURecipes(event) {
 
 	event.remove({ id: 'gtceu:rock_breaker/red_granite' })
 
+	// Snow Stuffs
+
+	event.remove({ id: 'gtceu:fluid_solidifier/snow_block' })
+	event.remove({ id: 'gtceu:fluid_solidifier/snow_block_distilled' })
+
+	removeCutterRecipe(event, 'snow_layer')
+	removeCutterRecipe(event, 'snow_layer_distilled_water')
+	removeCutterRecipe(event, 'snow_layer_water')
+
 	// Remove vanilla Eye of Ender
 
 	event.remove({ id: 'minecraft:ender_eye' })

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -316,7 +316,7 @@ const registerRailWaysRecipes = (event) => {
 	], {
 		A: '#forge:plates/wrought_iron',
 		B: '#forge:rods/wrought_iron',
-		C: 'create:propeller',
+		C: '#forge:rotors/iron',
 	}).id('tfg:railways/shaped/smokestack_diesel')
 
 	// Монорельс

--- a/kubejs/server_scripts/tfg/recipes.miscellaneous.js
+++ b/kubejs/server_scripts/tfg/recipes.miscellaneous.js
@@ -252,7 +252,7 @@ function registerTFGMiscellaneousRecipes(event) {
 		.EUt(GTValues.VA[GTValues.ULV])
 
 	event.recipes.gtceu.fluid_solidifier('tfg:ice')
-		.inputFluids(JsonIO.of({ amount: 100, value: { tag: "tfg:clean_water" } }))
+		.inputFluids(JsonIO.of({ amount: 144, value: { tag: "tfg:clean_water" } }))
 		.notConsumable('gtceu:block_casting_mold')
 		.itemOutputs('minecraft:ice')
 		.duration(200)


### PR DESCRIPTION
#1290 Add circuit 2 to all rocket recipes that hadn't a circuit after verifying no conflict
#1295 Fixing all the dumb snow stuffs
#1302 Putting Iron rotor in place of the Create one

Fixing the Autoclave MV recipe to make Rose quartz while skipping the ore
Fixing all water type into ice for 144mb and not 100mb to keep consistent with GTceu
