### PR TITLE
Begin Portuguese (Brazil) translation of Field Guide content

### DIFF
--- a/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/categories/beneath.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/categories/beneath.json
@@ -1,0 +1,6 @@
+{
+	"name": "O Nether...?",
+	"description": "Tudo sobre o que está nas Profundezas",
+	"icon": "minecraft:netherrack",
+	"sortnum": 10
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/categories/tfg_ores.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/categories/tfg_ores.json
@@ -1,0 +1,6 @@
+{
+    "name": "Minérios no TFG",
+    "description": "O TFG tem seu próprio sistema de geração de minérios que é similar ao do TFC, mas com veios gigantescos e raros porém com múltiplos minerais por veio. Esta categoria lista todos os tipos de veios e onde encontrá-los.$(br2)Os veios são nomeados de acordo com seu minério mais dominante, mas a maioria dos veios contém de 3 a 5 minerais.$(br2)Veja também: $(l:the_world/geology)Geologia$(), $(l:getting_started/finding_ores)Indicadores$()",
+    "icon": "tfc:ore/pyrite",
+	"sortnum": 60
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/categories/tfg_tips.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/categories/tfg_tips.json
@@ -1,0 +1,6 @@
+{
+	"name": "Informações e Dicas do TFG",
+	"description": "Informações sobre coisas no TerraFirmaGreg que são diferentes do TFC e GTCEu padrões.",
+	"icon": "gtceu:basic_electronic_circuit",
+	"sortnum": 200
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/entries/firmalife/irrigation.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/entries/firmalife/irrigation.json
@@ -1,0 +1,28 @@
+{
+	"name": "Irrigação",
+	"category": "tfc:firmalife",
+	"icon": "firmalife:sprinkler",
+	"pages": [
+		{
+			"type": "patchouli:text",
+			"text": "O $(thing)Aspersor$() é um dispositivo que borrifa água em uma área de 5x6x5 centralizada no bloco abaixo dele. Você sabe que ele está funcionando quando ele goteja partículas de água. Aspersores colocados virados para cima irrigam a mesma área de 5x6x5 só que voltada para cima."
+		},
+		{
+			"type": "tfc:anvil_recipe",
+			"recipe": "firmalife:anvil/sprinkler",
+			"text": "O aspersor é feito com uma $(thing)Placa de Cobre$()."
+		},
+		{
+			"title": "Tubulação",
+			"item": "gtceu:copper_tiny_fluid_pipe",
+			"type": "patchouli:spotlight",
+			"text": "Aspersores precisam ser conectados a um sistema de tubulações que os alimentam com água para funcionar. Isso é feito conectando uma série de $(thing)Tubos de Fluido$() a eles. Você pode bombear água para eles com uma $(thing)Bomba Mecânica$()."
+		},
+		{
+			"type": "patchouli:text",
+			"text": "Você pode clicar com o botão direito em um cano com uma Moldura do GregTech (como uma $(thing)Moldura de Cobre$()) para deixá-los embutidos com a parede, ou usar uma Conexão de Estufa. Depois, basta acoplar seu aspersor diretamente ao cano! Use uma chave inglesa em canos de fluido para alterar sua direção e clique enquanto agacha com a $(thing)segunda mão vazia$() para torná-los unidirecionais."
+		}
+	],
+	"read_by_default": true,
+	"sortnum": 8
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/entries/tfg_ores/hazards.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/entries/tfg_ores/hazards.json
@@ -1,0 +1,89 @@
+{
+	"name": "Materiais Perigosos",
+	"icon": "createdeco:decal_skull",
+	"category": "tfc:tfg_ores",
+	"priority": true,
+	"sortnum": 1,
+	"read_by_default": true,
+	"pages": [
+		{
+			"type": "patchouli:spotlight",
+			"title": "Materiais Perigosos",
+			"item": "gtceu:cobaltite_dust",
+			"text": "Alguns minérios e pós são perigosos e podem causar efeitos negativos ou até mesmo matá-lo se forem carregados em seu inventário.$(br2)Certos equipamentos, como $(thing)máscaras$(), $(thing)luvas$() e $(thing)trajes de materiais perigosos$(), mais tarde, podem ser usados para neutralizar esses efeitos."
+		},
+		{
+			"type": "patchouli:crafting",
+			"title": "Máscara Facial",
+			"recipe": "gtceu:shaped/face_mask",
+			"text": "A $(thing)Máscara Facial$() fornece proteção contra quaisquer perigos de $(item)Inalação$(), como Arsenicose."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"item": "gtceu:rubber_gloves",
+			"title": "Luvas de Borracha",
+			"link_recipes": true,
+			"text": "Luvas de Borracha podem ser feitas de $(l:mechanics/leather_making)Couro$() e $(l:arborfirmacraft/making_rubber)Látex$(), ou de Chapas de Borracha. Elas oferecem proteção contra quaisquer riscos de $(item)Contato com a Pele$(), como Beriliose."
+		},
+		{
+			"type": "tfc:knapping_recipe",
+			"recipe": "tfchotornot:leather_knapping/mittens",
+			"text": "Primeiro, trabalhe o couro em mitenes."
+		},
+		{
+			"type": "tfc:sealed_barrel_recipe",
+			"recipe": "tfg:sealed_barrel/prepared_leather_gloves",
+			"text": "As Mitenes são então embebidas em $(thing)Vinagre$(), uma mistura de frutas e álcool."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"item": "tfg:latex_soaked_gloves",
+			"text": "Luvas de couro preparadas são então aquecidas em uma $(thing)cubat$() com $(thing)Látex Vulcanizado$(), a um passo da borracha."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"item": "gtceu:rubber_gloves",
+			"text": "Por fim, as luvas embebidas em látex são aquecidas em um $(l:firmalife/oven)Forno$()."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"title": "Rochas",
+			"item": { "tag": "tfc:rock_knapping" },
+			"text": "A maneira mais fácil de evitar que itens perigosos entrem no seu inventário é não pegá-los. $(br)Preencher seu inventário com $(thing)Rochas$(), por exemplo, permitirá que você escolha quais itens deseja pegar, permitindo que você lide com os perigosos de uma só vez mais tarde."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"title": "Recipientes",
+			"text": "Materiais perigosos só causam dano enquanto estiverem em seu $(thing)inventário$(), mas isso não se aplica a outros contêineres!$(br)Materiais perigosos não causarão dano enquanto estiverem em outro contêiner, como uma $(l:tfg_tips/inventory_management)Mochila$() ou $(l:getting_started/pottery#vessel)Vaso$(). $(thing)Clicar com o botão direito$() enquanto segura um vaso permitirá a transferência direta do seu conteúdo de e para outros contêineres.",
+			"item": "sophisticatedbackpacks:backpack,tfc:ceramic/vessel,tfc:ceramic/large_vessel"
+		},
+		{
+			"type": "patchouli:spotlight",
+			"title": "Água Termal",
+			"item": "tfc:bucket/spring_water",
+			"text": "Ficar na $(thing)Água Termal$() causará um efeito lento de $(thing)Regeneração$()."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"title": "Álcool Envelhecido",
+			"text": "$(thing)Álcool Envelhecido$() dará bônus de poções, alguns dos quais você pode achar úteis.$(br2)Você pode bebê-las com um $(l:getting_started/pottery#jug)Cântaro$() ou um $(l:waterflasks/recipes)Cantil$().",
+			"item": "tfcagedalcohol:bucket/aged_beer,tfcagedalcohol:bucket/aged_cider,tfcagedalcohol:bucket/aged_rum,tfcagedalcohol:bucket/aged_sake,tfcagedalcohol:bucket/aged_vodka,tfcagedalcohol:bucket/aged_whiskey,tfcagedalcohol:bucket/aged_corn_whiskey,tfcagedalcohol:bucket/aged_rye_whiskey"
+		},
+		{
+			"type": "patchouli:text",
+			"text": "Cerveja Envelhecida: Absorção II (20:00)$(br2)Sidra Envelhecida: Velocidade (5:20)$(br2)Rum Envelhecido: Velocidade II (2:40)$(br2)Saquê Envelhecido: Resistência (5:20)$(br2)Vodca Envelhecida: Resistência II (2:40)$(br2)Uísque de Milho Envelhecido: Pressa (5:20)$(br2)Uísque de Centeio Envelhecido: Pressa (5:20)$(br2)Uísque Envelhecido: Pressa II (2:40)"
+		},
+		{
+			"type": "patchouli:spotlight",
+			"item": { "tag": "tfc:foods" },
+			"title": "Nutrição",
+			"text": "Comer alimentos melhores com mais $(l:getting_started/food_and_water#nutrients)nutrição$() aumentará seu HP máximo em uma quantidade significativa.$(br2)$(l:mechanics/pot#soup)Sopas$(), $(l:mechanics/sandwiches)Sanduíches$() e $(l:mechanics/salad)Saladas$() são ótimos para isso."
+		},
+		{
+			"type": "patchouli:spotlight",
+			"title": "Cama",
+			"item": { "tag": "minecraft:beds" },
+			"text": "Se tudo mais falhar, levar uma cama para renascer é uma boa ideia.$(br2)Se você não tiver acesso a $(thing)Lã$() ou $(thing)Linha$(), você também pode fazer uma $(l:getting_started/a_place_to_sleep)Cama de Palha$()."
+		}
+	]
+}

--- a/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/entries/tfg_ores/ore_basics.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/pt_br/entries/tfg_ores/ore_basics.json
@@ -1,0 +1,43 @@
+{
+    "name": "Mineração no TFG",
+    "icon": "minecraft:diamond_pickaxe",
+    "category": "tfc:tfg_ores",
+    "priority": true,
+    "sortnum": 0,
+    "pages": [
+        {
+            "type": "patchouli:text",
+            "text": "Você precisará de uma $(thing)picareta$() ou uma $(thing)marreta de mineração$() para minerar minérios.$(br2)Um $(thing)martelo$() comum também pode quebrar blocos de pedra rapidamente, mas não dropará minérios. No entanto, ele ainda pode ser útil para $(l:getting_started/primitive_anvils#raw_rock)extrair$() blocos de pedra."
+        },
+        {
+            "type": "patchouli:crafting",
+            "recipe": "gtceu:shaped/pickaxe_copper",
+            "recipe2": "gtceu:shaped/mining_hammer_copper"
+        },
+        {
+            "type": "patchouli:spotlight",
+            "title": "Picareta",
+            "text": "Quebrar um bloco de minério com uma picareta renderá $(thing)minérios brutos$() (pobres, normais ou ricos), além de um pouco de pó de pedra. Cada um deles não vale muitos mB e você precisará de vários para fazer um único lingote. No entanto, alguns outros minerais só podem ser usados nesse estado, como $(thing)carvão$().",
+            "item": { "tag": "minecraft:pickaxes" }
+        },
+        {
+            "type": "patchouli:spotlight",
+            "title": "Marreta de Mineração",
+            "text": "Basicamente, são picaretas com alcance 3x3 e também rendem $(thing)minérios brutos$(). Também são boas para limpar pedras depois de martelar os minérios!$(br2)Segurar $(thing)agachar$() quebrará apenas um bloco por vez.",
+            "item": { "tag": "forge:tools/mining_hammers" }
+        },
+        {
+            "type": "patchouli:spotlight",
+            "title": "Processamento básico de minério",
+            "anchor": "processing",
+            "item": "gtceu:crushed_copper_ore",
+            "text": "O processamento de minérios resultará em quantidades muito maiores de metal utilizável. O primeiro passo é usar uma $(l:mechanics/quern)Pedra Mó$() para triturar o minério bruto. Essa etapa pode ser automatizada no futuro com máquinas aprimoradas, como a $(thing)Moenda$(), a $(thing)Roda de Esmagamento$(), o $(thing)Macerador$() e o $(thing)Martelo de Forja$()."
+        },
+        {
+            "type": "patchouli:crafting",
+            "title": "Purificando pó",
+            "recipe": "gtceu:shapeless/crushed_ore_to_dust_copper",
+            "text": "Para fazer seus minérios triturados derreterem em ainda mais mB, primeiro coloque-os em uma grade de criação junto com um $(thing)Martelo$(). Isso produzirá $(thing)Pó Impuro$(). Para purificar o pó, jogue-o na água ou $(item)$(k:key.use)$() um $(thing)Caldeirão$() cheio de água."
+        }
+    ]
+}


### PR DESCRIPTION
## What is the new behavior?
This PR adds Brazilian Portuguese (`pt_br`) language support to the Field Guide by:

- Adding `pt_br` translations for all entries in the `categories` folder.
- Adding `pt_br` entries specifically for the **Irrigation**, **Hazards** and **Mining** sections.

These additions aim to improve accessibility and localization for Portuguese-speaking players.

## Implementation Details
- Translated all JSON files in the `categories` folder to `pt_br`, maintaining original structure and formatting.
- Localized new entries for Irrigation and Hazards with accurate terminology consistent with the modpack context.
- Ensured consistency and correctness across the newly added translations.

## Outcome
- Added full `pt_br` language support for the `categories` folder.
- Added new `pt_br` entries for Irrigation and Hazards in the Field Guide.

These improvements enhance the experience for Brazilian players by providing key content in their native language.

## Additional Information
No changes affect the GUI or rendering; this PR only introduces localization files.

## Potential Compatibility Issues
No compatibility issues expected, as this only adds new translation content.

@gifpxto