### PR TITLE
Bugfix/glass item drop compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed Ad Astra space suit quest mentioning oxygen instead of breathable gas (#1353) @Redeix
 - Fixed flintlock not being craftable before LV (#1353) @Redeix
 - Fixed the field guide not working for chinese players (#1356) @Pyritie
+- Fixed glass blocks dropping with gem saw (#1363) @BlueBoat29
 
 ## [0.10.0] - 13.07.2025
 - [!WARNING] If you're upgrading your world from 0.9 to 0.10, please read the upgrade guide [here](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/wiki/%5BEN%5D-Upgrading-from-0.9-to-0.10). We do not recommend using Alpha versions for progression, but if you do, please make frequent backups!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Increased maximum range of rope/elevator pulleys to 400 blocks (#1347) @Pyritie
 - Added Tier 2 Insulation: Alkaline Earth Silicate @BlueBoat29
 - Added tfc data to tacz guns and attachments (#1353) @Redeix
+- Allowed "window" blocks and panes to be broken and picked up @BlueBoat29
 ### Bug fixes
 - Fixed yeast food processor conflict (#1310) @Redeix
 - Fixed seed oil voiding in barrels (#1310) @Redeix
@@ -39,7 +40,7 @@
 - Fixed Ad Astra space suit quest mentioning oxygen instead of breathable gas (#1353) @Redeix
 - Fixed flintlock not being craftable before LV (#1353) @Redeix
 - Fixed the field guide not working for chinese players (#1356) @Pyritie
-- Fixed glass blocks dropping with gem saw (#1363) @BlueBoat29
+- Fixed glass blocks dropping with gem saw (#1367) @BlueBoat29
 
 ## [0.10.0] - 13.07.2025
 - [!WARNING] If you're upgrading your world from 0.9 to 0.10, please read the upgrade guide [here](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/wiki/%5BEN%5D-Upgrading-from-0.9-to-0.10). We do not recommend using Alpha versions for progression, but if you do, please make frequent backups!

--- a/kubejs/server_scripts/tfg/loot_tables.js
+++ b/kubejs/server_scripts/tfg/loot_tables.js
@@ -88,4 +88,67 @@ function registerTFGLoots(event) {
         .addLoot('minecraft:campfire')
 
     //#endregion
+	
+	//Cross-mod glass compat
+	const STRONG_GLASSES = [
+		['create:dark_oak_window', true],
+		['create:mangrove_window', true],
+		['create:ornate_iron_window', true],
+		['create:industrial_iron_window', true],
+		['create:weathered_iron_window', true],
+		['create:cherry_window', true],
+		['create:bamboo_window', true],
+		['createdeco:andesite_window', true],
+		['createdeco:copper_window', true],
+		['createdeco:iron_window', true], 
+		['createdeco:industrial_iron_window', true],
+		['createdeco:brass_window', true],
+		['createdeco:zinc_window', true],
+		['everycomp:c/domum_ornamentum/cactus_window_pane', false],
+		['everycomp:c/domum_ornamentum/cactus_extra_window_pane', false]
+	]
+	const GLASSES = [
+		'create:framed_glass',
+		'create:vertical_framed_glass',
+		'create:horizontal_framed_glass',
+		'create:tiled_glass'
+	]
+	
+	STRONG_GLASSES.forEach(glass => {
+		event.addBlockLootModifier(glass[0])
+			.addLoot(glass[0])
+		if(glass[1]){
+			event.addBlockLootModifier(glass[0] + "_pane")
+			.addLoot(glass[0] + "_pane")
+		}
+		
+	});
+	
+	GLASSES.forEach(glass => {
+		event.addBlockLootModifier(glass)
+			.matchMainHand(Item.of('tfc:gem_saw'))
+			.addLoot(glass)
+		event.addBlockLootModifier(glass + "_pane")
+			.matchMainHand(Item.of('tfc:gem_saw'))
+			.addLoot(glass + "_pane")
+		
+	})
+	
+	global.TFC_WOOD_TYPES.forEach(wood => {
+		const id = 'everycomp:c/tfc/' + wood + "_window_pane"
+		event.addBlockLootModifier(id)
+			.addLoot(id)
+	})
+	global.AFC_WOOD_TYPES.forEach(wood => {
+		const id = 'everycomp:c/afc/' + wood + "_window_pane"
+		event.addBlockLootModifier(id)
+			.addLoot(id)
+	})
+	
+	global.AD_ASTRA_WOOD.forEach(wood => {
+		const id = 'everycomp:c/ad_astra/' + wood.name + "_window_pane"
+		event.addBlockLootModifier(id)
+			.addLoot(id)
+	})
+	
 };


### PR DESCRIPTION
- Allowed "window" blocks and panes to be broken and picked up 
everycompat already does this, so it's more of a unification between blocks and panes

- Fixed glass blocks dropping with gem saw (#1367)
only did this for the create glass, but it's easy to add for other glasses