### PR TITLE
Pink Thorium

### DIFF
--- a/kubejs/startup_scripts/gtceu/materials.js
+++ b/kubejs/startup_scripts/gtceu/materials.js
@@ -321,6 +321,8 @@ const registerGTCEuMaterialModification = (event) => {
 	GTMaterials.Platinum.setMaterialSecondaryARGB(0x59563a)
 	GTMaterials.Nickel.setMaterialARGB(0xfff4ba)
 	GTMaterials.Nickel.setMaterialSecondaryARGB(0x8d8d71)
+	GTMaterials.Thorium.setMaterialARGB(0xf8a8c0)
+	GTMaterials.Thorium.setMaterialSecondaryARGB(0xcd8dbc)
 
 	
 	global.MINECRAFT_DYE_NAMES.forEach(colorName =>


### PR DESCRIPTION
## What is the new behavior?

* Makes thorium pink

## Implementation Details

* I used a colorpicker

## Outcome

* Thorium is now Pink
<img width="616" height="192" alt="image" src="https://github.com/user-attachments/assets/5f90e344-ed15-4f96-9160-ac7dcefb50bf" />


## Additional Information

* I made it pink to turn it into an Obscure Mindustry reference, plus, I saw some developers where looking to recolor it to differentiate from another material.

<img width="32" height="32" alt="image" src="https://github.com/user-attachments/assets/17ad8bbe-121c-4e71-81f2-75bbc95bccc1" />

## Potential Compatibility Issues

If you don't like pink then this may be a downgrade