### PR TITLE
Added some performance oriented options to ModernFix

### DIFF
--- a/config/modernfix-mixins.properties
+++ b/config/modernfix-mixins.properties
@@ -107,4 +107,14 @@
 #  mixin.safety=true # (default)
 #
 # User overrides go here.
+mixin.bugfix.packet_leak=true
+mixin.feature.disable_unihex_font=true
+mixin.feature.spark_profile_launch=true
+mixin.perf.clear_mixin_classinfo=true
+mixin.perf.deduplicate_location=true
+mixin.perf.dynamic_entity_renderers=true
+mixin.perf.dynamic_resources=true
+mixin.perf.faster_item_rendering=true
+mixin.perf.remove_spawn_chunks=true
 mixin.perf.smart_ingredient_sync=false
+mixin.perf.worldgen_allocation=true


### PR DESCRIPTION
## What is the new behavior?
As per my testing, Minecraft's launch memory use was reduced around 1 GB and around 15 seconds faster.

## Outcome
Less memory use overall.

## Potential Compatibility Issues
CAUTION! This may add other side effects like crashes or bugs it needs more testing.

Discord: victordlp8