### PR TITLE
Added concrete into facade materials

### DIFF
--- a/kubejs/server_scripts/tfg/tags.facades.js
+++ b/kubejs/server_scripts/tfg/tags.facades.js
@@ -21,6 +21,7 @@ function registerFacadeWhitelistTags(event) {
 		'#forge:storage_blocks',
 		'#forge:glass',
 		'#minecraft:terracotta',
+		'#forge:concretes',
 		'#create:casing',
 		'#dormum_ornamentum:brick_items',
 		'#simplylight:any_lamp_on',


### PR DESCRIPTION
## What is the new behavior?
Between all the items that can be used to make a GregTech facade, concrete is missing.
Since wood and gravel are available, I felt like concrete, a much more stable material, should be available as well.

## Implementation Details
Just added a tag representing concrete in to tags.facades.js

## Outcome
Concrete facades \o/
<img width="928" height="431" alt="image" src="https://github.com/user-attachments/assets/96b627d8-e233-42e8-bb09-0b61b1cb2dcb" />


## Potential Compatibility Issues
There is no `#minecraft:concrete`, so if any future mod adds blocks tagged `#forge:concretes`, it would be added to facade list as well, which may not be desirable.

**Discord nick:**
`theashenwolf`