### PR TITLE
Remove cinnabar to redstone recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed a crash when trying to spawn rabbits on the moon (#1528) @Pyritie
 - Fixed duplicate Create recipes @Pyritie
 - Prevented hammers, wrenches, and spades from being placed in chests to match other tools. (#1538) @dimethylene
+- Removed cinnabar to redstone recipe, which generated free resources. (#1548) @SpicyNoodle5
 
 ## [0.10.5] - 03-08-2025
 ### Major changes

--- a/kubejs/startup_scripts/tfc/constants.js
+++ b/kubejs/startup_scripts/tfc/constants.js
@@ -946,7 +946,6 @@ global.TFC_QUERN_POWDER_RECIPE_COMPONENTS = [
     { input: '#forge:dusts/malachite', output: '4x tfc:powder/malachite', name: 'malachite_powder' },
     { input: '#forge:dusts/yellow_limonite', output: '4x tfc:powder/limonite', name: 'limonite_powder' },
     { input: '#forge:dusts/hematite', output: '4x tfc:powder/hematite', name: 'hematite_powder' },
-    { input: '#forge:dusts/cinnabar', output: '4x minecraft:redstone', name: 'cinnabar_powder' },
     { input: '#forge:dusts/sulfur', output: '4x tfc:powder/sulfur', name: 'sulfur_powder' },
     { input: '#forge:dusts/saltpeter', output: '4x tfc:powder/saltpeter', name: 'saltpeter_powder' },
     { input: '#forge:dusts/salt', output: '4x tfc:powder/salt', name: 'salt_powder' },


### PR DESCRIPTION
## What is the new behavior?
Remove quern/macerator recipes to turn cinnabar to redstone

## Implementation Details
Removed the recipe defined in global.TFC_QUERN_POWDER_RECIPE_COMPONENTS

## Outcome
Before this recipe generated free resources by crushing cinnabar to redstone, then centrifuging that redstone. E.g 10 cinnabar usually gives 5B mercury, but crushing this gave 40 redstone which centrifuges to 12B mercury + extra resources.

## Potential Compatibility Issues
This recipe was added at some point, presumably for the early game as it was a quern recipe. But it seems redundant as you can just mine redstone and cinnabar is not required for progressing. It would be easy to add a similar recipe back in if it turns out there was a need for it.

Discord: spicy_noodle5