### PR TITLE
Rework of all resins

### DIFF
--- a/kubejs/server_scripts/afc/recipes.js
+++ b/kubejs/server_scripts/afc/recipes.js
@@ -130,7 +130,7 @@ const registerAFCRecipes = (event) => {
 		.minTemp(12)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/kapok_latex")
-	event.recipes.afc.tree_tapping(TFC.blockIngredient("tfc:wood/log/ancient_kapok"))
+	event.recipes.afc.tree_tapping(TFC.blockIngredient("afc:wood/log/ancient_kapok"))
 		.resultFluid(Fluid.of("tfg:latex", 3))
 		.minTemp(12)
 		.requiresNaturalLog(true)
@@ -143,7 +143,7 @@ const registerAFCRecipes = (event) => {
 		.minTemp(-10)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/aspen_resin")
-	event.recipes.afc.tree_tapping(TFC.blockIngredient("tfc:wood/log/ancient_aspen"))
+	event.recipes.afc.tree_tapping(TFC.blockIngredient("afc:wood/log/ancient_aspen"))
 		.resultFluid(Fluid.of('tfg:conifer_pitch', 2))
 		.minTemp(-10)
 		.requiresNaturalLog(true)
@@ -154,7 +154,7 @@ const registerAFCRecipes = (event) => {
 		.minTemp(-15)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/spruce_resin")
-	event.recipes.afc.tree_tapping(TFC.blockIngredient("tfc:wood/log/ancient_spruce"))
+	event.recipes.afc.tree_tapping(TFC.blockIngredient("afc:wood/log/ancient_spruce"))
 		.resultFluid(Fluid.of('tfg:conifer_pitch', 4))
 		.minTemp(-15)
 		.requiresNaturalLog(true)
@@ -165,23 +165,26 @@ const registerAFCRecipes = (event) => {
 		.minTemp(-8)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/white_cedar_resin")
-	event.recipes.afc.tree_tapping(TFC.blockIngredient("tfc:wood/log/ancient_white_cedar"))
+	event.recipes.afc.tree_tapping(TFC.blockIngredient("afc:wood/log/ancient_white_cedar"))
 		.resultFluid(Fluid.of('tfg:conifer_pitch', 3))
 		.minTemp(-8)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/ancient_white_cedar_resin")
 
-	event.recipes.afc.tree_tapping(TFC.blockIngredient("tfc:wood/log/douglas_fir"))
+	event.recipes.afc.tree_tapping(TFC.blockIngredient('tfc:wood/log/douglas_fir'))
 		.resultFluid(Fluid.of('tfg:conifer_pitch', 2))
 		.minTemp(-8)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/douglas_fir_resin")
-	event.recipes.afc.tree_tapping(TFC.blockIngredient("tfc:wood/log/ancient_douglas_fir"))
+	event.recipes.afc.tree_tapping(TFC.blockIngredient("afc:wood/log/ancient_douglas_fir"))
 		.resultFluid(Fluid.of('tfg:conifer_pitch', 2))
 		.minTemp(-8)
 		.requiresNaturalLog(true)
 		.id("tfg:tree_tapping/ancient_douglas_fir_resin")
 
+	//#region Extractor Recipe
+
+	// Latex
 
 	event.recipes.gtceu.extractor('latex_from_log')
 		.itemInputs('#tfg:latex_logs')
@@ -201,59 +204,119 @@ const registerAFCRecipes = (event) => {
 		.duration(750)
 		.EUt(20)
 
-	event.replaceOutput({ id: 'gtceu:centrifuge/sticky_resin_separation' }, 'gtceu:raw_rubber_dust', '3x gtceu:carbon_dust')
+	// Conifer Pitch
+
+	event.recipes.gtceu.extractor('conifer_from_log')
+		.itemInputs('#tfg:rosin_logs')
+		.outputFluids(Fluid.of('tfg:conifer_pitch', 250))
+		.duration(600)
+		.EUt(20)
+
+	event.recipes.gtceu.extractor('conifer_from_sapling')
+		.itemInputs('#tfg:rosin_saplings')
+		.outputFluids(Fluid.of('tfg:conifer_pitch', 100))
+		.duration(750)
+		.EUt(20)
+
+	event.recipes.gtceu.extractor('conifer_from_leaves')
+		.itemInputs('#tfg:rosin_leaves')
+		.outputFluids(Fluid.of('tfg:conifer_pitch', 50))
+		.duration(750)
+		.EUt(20)
+
+	// Maple Sirup
+
+	event.recipes.gtceu.extractor('maple_from_log')
+		.itemInputs('#tfc:maple_logs')
+		.outputFluids(Fluid.of('afc:maple_sap', 250))
+		.duration(600)
+		.EUt(20)
+
+	event.recipes.gtceu.extractor('maple_from_sapling')
+		.itemInputs('#tfg:maple_saplings')
+		.outputFluids(Fluid.of('afc:maple_sap', 100))
+		.duration(750)
+		.EUt(20)
+
+	event.recipes.gtceu.extractor('maple_from_leaves')
+		.itemInputs('#tfg:maple_leaves')
+		.outputFluids(Fluid.of('afc:maple_sap', 50))
+		.duration(750)
+		.EUt(20)
+
+	// Birch Sirup
+
+	event.recipes.gtceu.extractor('birch_from_log')
+		.itemInputs('#tfc:birch_logs')
+		.outputFluids(Fluid.of('afc:birch_sap', 250))
+		.duration(600)
+		.EUt(20)
+
+	event.recipes.gtceu.extractor('birch_from_sapling')
+		.itemInputs('tfc:wood/sapling/birch')
+		.outputFluids(Fluid.of('afc:birch_sap', 100))
+		.duration(750)
+		.EUt(20)
+
+	event.recipes.gtceu.extractor('birch_from_leaves')
+		.itemInputs('tfc:wood/leaves/birch')
+		.outputFluids(Fluid.of('afc:birch_sap', 50))
+		.duration(750)
+		.EUt(20)
 
 	//#endregion
 
-	// Из бревна капока
+	// Из бревна капока / Logs Centrifuge
 	event.recipes.gtceu.centrifuge('rubber_log_separation')
 		.itemInputs('#tfg:latex_logs')
-		.chancedOutput('gtceu:raw_rubber_dust', 5000, 1200)
-		.chancedOutput('gtceu:plant_ball', 3750, 900)
-		.chancedOutput('gtceu:sticky_resin', 2500, 600)
-		.chancedOutput('gtceu:wood_dust', 2500, 700)
+		.chancedOutput('gtceu:raw_rubber_dust', 5000, 0)
+		.chancedOutput('gtceu:plant_ball', 3750, 0)
+		.chancedOutput('gtceu:sticky_resin', 2500, 0)
+		.chancedOutput('gtceu:wood_dust', 2500, 0)
 		.outputFluids(Fluid.of('gtceu:methane', 60))
-		.duration(200)
-		.EUt(20)
+		.duration(20*20)
+		.EUt(GTValues.VA[GTValues.MV])
 
 	event.recipes.gtceu.centrifuge('conifer_log_separation')
 		.itemInputs('#tfg:rosin_logs')
-		.chancedOutput('tfg:conifer_rosin', 7500, 1200)
-		.chancedOutput('gtceu:plant_ball', 3750, 900)
-		.chancedOutput('gtceu:sticky_resin', 2500, 600)
-		.chancedOutput('gtceu:wood_dust', 2500, 700)
+		.chancedOutput('tfg:conifer_rosin', 7500, 0)
+		.chancedOutput('gtceu:plant_ball', 3750, 0)
+		.chancedOutput('gtceu:sticky_resin', 2500, 0)
+		.chancedOutput('gtceu:wood_dust', 2500, 0)
 		.outputFluids(Fluid.of('gtceu:methane', 60))
-		.duration(200)
-		.EUt(20)
+		.duration(20*20)
+		.EUt(GTValues.VA[GTValues.MV])
 
 	event.recipes.gtceu.centrifuge('maple_syrup_log_separation')
 		.itemInputs('#tfc:maple_logs')
-		.chancedOutput('afc:maple_sugar', 7500, 1200)
-		.chancedOutput('gtceu:plant_ball', 3750, 900)
-		.chancedOutput('gtceu:wood_dust', 2500, 700)
+		.chancedOutput('afc:maple_sugar', 7500, 0)
+		.chancedOutput('gtceu:plant_ball', 3750, 0)
+		.chancedOutput('gtceu:wood_dust', 2500, 0)
 		.outputFluids(Fluid.of('gtceu:methane', 60), Fluid.of('afc:maple_syrup', 100))
-		.duration(200)
-		.EUt(20)
+		.duration(20*20)
+		.EUt(GTValues.VA[GTValues.MV])
 
 	event.recipes.gtceu.centrifuge('birch_syrup_log_separation')
 		.itemInputs('#tfc:birch_logs')
-		.chancedOutput('afc:birch_sugar', 7500, 1200)
-		.chancedOutput('gtceu:plant_ball', 3750, 900)
-		.chancedOutput('gtceu:wood_dust', 2500, 700)
+		.chancedOutput('afc:birch_sugar', 7500, 0)
+		.chancedOutput('gtceu:plant_ball', 3750, 0)
+		.chancedOutput('gtceu:wood_dust', 2500, 0)
 		.outputFluids(Fluid.of('gtceu:methane', 60), Fluid.of('afc:birch_syrup', 100))
-		.duration(200)
-		.EUt(20)
+		.duration(20*20)
+		.EUt(GTValues.VA[GTValues.MV])
 
 	//#endregion
 
 	//region gt sap processing
+
 	event.recipes.gtceu.fluid_heater('maple_sap_condense')
-		.inputFluids(Fluid.of('afc:maple_sap', 4000))
+		.inputFluids(Fluid.of('afc:maple_sap', 1000))
 		.outputFluids(Fluid.of('afc:maple_syrup', 100))
 		.duration(20*25)
 		.EUt(GTValues.VA[GTValues.ULV])
+
 	event.recipes.gtceu.fluid_heater('birch_sap_condense')
-		.inputFluids(Fluid.of('afc:birch_sap', 8000))
+		.inputFluids(Fluid.of('afc:birch_sap', 1000))
 		.outputFluids(Fluid.of('afc:birch_syrup', 100))
 		.duration(20*35)
 		.EUt(GTValues.VA[GTValues.ULV])
@@ -264,14 +327,14 @@ const registerAFCRecipes = (event) => {
 	event.recipes.gtceu.fluid_solidifier('maple_syrup')
 		.inputFluids(Fluid.of('afc:maple_syrup', 100))
 		.itemOutputs('afc:maple_sugar')
-		.duration(500)
-		.EUt(GTValues.VA[GTValues.ULV])
+		.duration(20*12)
+		.EUt(GTValues.VHA[GTValues.ULV])
 
 	event.recipes.gtceu.fluid_solidifier('birch_syrup')
 		.inputFluids(Fluid.of('afc:birch_syrup', 100))
 		.itemOutputs('afc:birch_sugar')
-		.duration(500)
-		.EUt(GTValues.VA[GTValues.ULV])
+		.duration(20*12)
+		.EUt(GTValues.VHA[GTValues.ULV])
 
 	// Stripped logs
 

--- a/kubejs/server_scripts/afc/tags.js
+++ b/kubejs/server_scripts/afc/tags.js
@@ -43,14 +43,11 @@ const registerAFCItemTags = (event) => {
 		event.add('minecraft:saplings', `afc:wood/sapling/${x.sapling}`)
 	})
 
+	// Latex Tag
+
 	event.add("tfg:latex_logs", "#tfc:kapok_logs")
     event.add("tfg:latex_logs", "#afc:hevea_logs")
     event.add("tfg:latex_logs", "#afc:rubber_fig_logs")
-
-	event.add("tfg:rosin_logs", "#tfc:aspen_logs")
-	event.add("tfg:rosin_logs", "#tfc:spruce_logs")
-	event.add("tfg:rosin_logs", "#tfc:white_cedar_logs")
-	event.add("tfg:rosin_logs", "#tfc:douglas_fir_logs")
 
     event.add("tfg:rubber_saplings", "tfc:wood/sapling/kapok")
 	event.add("tfg:rubber_saplings", "afc:wood/sapling/red_silk_cotton")
@@ -62,13 +59,48 @@ const registerAFCItemTags = (event) => {
     event.add("tfg:rubber_leaves", "afc:wood/leaves/hevea")
     event.add("tfg:rubber_leaves", "afc:wood/leaves/rubber_fig")
 
+	// Rosin Tag
+
+	event.add("tfg:rosin_logs", "#tfc:aspen_logs")
+	event.add("tfg:rosin_logs", "#tfc:spruce_logs")
+	event.add("tfg:rosin_logs", "#tfc:white_cedar_logs")
+	event.add("tfg:rosin_logs", "#tfc:douglas_fir_logs")
+
+	event.add("tfg:rosin_saplings", 'tfc:wood/leaves/aspen')
+	event.add("tfg:rosin_saplings", 'afc:wood/leaves/coast_spruce')
+	event.add("tfg:rosin_saplings", 'tfc:wood/leaves/spruce')
+	event.add("tfg:rosin_saplings", 'afc:wood/leaves/black_spruce')
+	event.add("tfg:rosin_saplings", 'afc:wood/leaves/sitka_spruce')
+	event.add("tfg:rosin_saplings", 'tfc:wood/leaves/douglas_fir')
+	event.add("tfg:rosin_saplings", 'tfc:wood/leaves/white_cedar')
+
+	event.add("tfg:rosin_leaves", 'tfc:wood/sapling/aspen')
+	event.add("tfg:rosin_leaves", 'afc:wood/sapling/coast_spruce')
+	event.add("tfg:rosin_leaves", 'tfc:wood/sapling/spruce')
+	event.add("tfg:rosin_leaves", 'afc:wood/sapling/black_spruce')
+	event.add("tfg:rosin_leaves", 'afc:wood/sapling/sitka_spruce')
+	event.add("tfg:rosin_leaves", 'tfc:wood/sapling/douglas_fir')
+	event.add("tfg:rosin_leaves", 'tfc:wood/sapling/white_cedar')
+
+	// Maple Syrup Tag
+
+	event.add("tfg:maple_saplings", 'tfc:wood/sapling/maple')
+	event.add("tfg:maple_saplings", 'afc:wood/sapling/bigleaf_maple')
+	event.add("tfg:maple_saplings", 'afc:wood/sapling/weeping_maple')
+
+	event.add("tfg:maple_leaves", 'tfc:wood/leaves/maple')
+	event.add("tfg:maple_leaves", 'afc:wood/leaves/bigleaf_maple')
+	event.add("tfg:maple_leaves", 'tfc:wood/leaves/weeping_maple')
+
+	// Misc
+
 	event.add("tfg:rubber_plants", "tfc:plant/goldenrod")
 	event.add("tfg:rubber_plants", "tfc:plant/dandelion")
 }
 
 
 /**
- * 
+ * @
  * @param {TagEvent.Block} event 
  */
 const registerAFCBlockTags = (event) => {

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -144,14 +144,14 @@ const registerGTCEURecipes = (event) => {
 		.id('tfg:pot/sticky_resin_from_conifer_pitch')
 
 	event.recipes.gtceu.fluid_solidifier('tfg:fluid_solidifier/latex_to_sticky_resin')
-		.duration(24 * 20)
+		.duration(12 * 20)
 		.EUt(30)
 		.itemInputs('tfc:powder/wood_ash')
 		.itemOutputs('gtceu:sticky_resin')
 		.inputFluids(Fluid.of('tfg:latex', 1000))
 
 	event.recipes.gtceu.fluid_solidifier('tfg:fluid_solidifier/pitch_to_sticky_resin')
-		.duration(24 * 20)
+		.duration(12 * 20)
 		.EUt(30)
 		.itemInputs('tfc:powder/wood_ash')
 		.itemOutputs('gtceu:sticky_resin')
@@ -485,11 +485,23 @@ const registerGTCEURecipes = (event) => {
 		D: 'gtceu:tin_single_cable'
 	}).id('gtceu:shaped/electric_blast_furnace2')
 
-	// Клей из ТФК клея
+	// Клей из ТФК клея / Glue from resin
 	event.recipes.gtceu.extractor('tfg:glue_from_tfc_glue')
 		.itemInputs('tfc:glue')
 		.outputFluids(Fluid.of('gtceu:glue', 50))
-		.duration(400)
+		.duration(20*10)
+		.EUt(5)
+
+	event.recipes.gtceu.extractor('tfg:glue_from_sticky_resin')
+		.itemInputs('gtceu:sticky_resin')
+		.outputFluids(Fluid.of('gtceu:glue', 100))
+		.duration(20*10)
+		.EUt(5)
+
+	event.recipes.gtceu.extractor('tfg:glue_from_conifer_resin')
+		.itemInputs('tfg:conifer_rosin')
+		.outputFluids(Fluid.of('gtceu:glue', 50))
+		.duration(20*10)
 		.EUt(5)
 
 	event.recipes.gtceu.mixer('tfg:glue_from_bone_meal')
@@ -975,9 +987,17 @@ const registerGTCEURecipes = (event) => {
 		.itemInputs('tfg:conifer_rosin')
 		.outputFluids(Fluid.of('gtceu:glue', 50))
 		.itemOutputs('2x #forge:dusts/carbon')
-		.chancedOutput('gtceu:plant_ball', 1000, 850)
-		.duration(400)
-		.EUt(GTValues.VA[GTValues.ULV])
+		.chancedOutput('gtceu:plant_ball', 7500, 0)
+		.duration(20*20)
+		.EUt(GTValues.VA[GTValues.LV])
+
+	event.recipes.gtceu.centrifuge('tfg:centrifuge_sticky_resin')
+		.itemInputs('gtceu:sticky_resin')
+		.outputFluids(Fluid.of('gtceu:glue', 100))
+		.itemOutputs('3x #forge:dusts/carbon')
+		.chancedOutput('gtceu:plant_ball', 5000, 0)
+		.duration(20*20)
+		.EUt(GTValues.VA[GTValues.LV])
 
 	event.recipes.gtceu.chemical_reactor(`tfg:treat_latex_plants_into_latex`)
 		.itemInputs('16x #tfg:rubber_plants', 'gtceu:tiny_sodium_hydroxide_dust')
@@ -1333,10 +1353,18 @@ const registerGTCEURecipes = (event) => {
 		F: 'gtceu:stainless_steel_huge_fluid_pipe'
 	}).id('tfg:shaped/large_centrifuge')
 
-	event.recipes.gtceu.extractor('tfg:logs_to_wood_gas')
-		.itemInputs('#minecraft:logs_that_burn')
+	event.recipes.gtceu.chemical_reactor('tfg:wood_ash_to_wood_gas_air')
+		.itemInputs('tfc:powder/wood_ash')
+		.inputFluids(Fluid.of('gtceu:air', 100))
 		.outputFluids('gtceu:wood_gas 100')
-		.duration(100)
+		.duration(20*5)
+		.EUt(GTValues.VA[GTValues.LV])
+
+	event.recipes.gtceu.chemical_reactor('tfg:wood_ash_to_wood_gas_oxygen')
+		.itemInputs('tfc:powder/wood_ash')
+		.inputFluids(Fluid.of('gtceu:oxygen', 100))
+		.outputFluids('gtceu:wood_gas 200')
+		.duration(20*5)
 		.EUt(GTValues.VA[GTValues.LV])
 
 	

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1354,20 +1354,12 @@ const registerGTCEURecipes = (event) => {
 	}).id('tfg:shaped/large_centrifuge')
 
 	event.recipes.gtceu.chemical_reactor('tfg:wood_ash_to_wood_gas_air')
-		.itemInputs('tfc:powder/wood_ash')
+		.itemInputs('8x tfc:powder/wood_ash')
 		.inputFluids(Fluid.of('gtceu:air', 100))
 		.outputFluids('gtceu:wood_gas 100')
 		.duration(20*5)
 		.EUt(GTValues.VA[GTValues.LV])
 
-	event.recipes.gtceu.chemical_reactor('tfg:wood_ash_to_wood_gas_oxygen')
-		.itemInputs('tfc:powder/wood_ash')
-		.inputFluids(Fluid.of('gtceu:oxygen', 100))
-		.outputFluids('gtceu:wood_gas 200')
-		.duration(20*5)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	
 	// Buttons
 	event.replaceOutput({ id: 'gtceu:cutter/blackstone_button' }, 'minecraft:polished_blackstone_button', '6x minecraft:polished_blackstone_button')
 	event.replaceOutput({ id: 'gtceu:cutter/blackstone_button_water' }, 'minecraft:polished_blackstone_button', '6x minecraft:polished_blackstone_button')

--- a/kubejs/server_scripts/gregtech/recipes.removes.js
+++ b/kubejs/server_scripts/gregtech/recipes.removes.js
@@ -712,6 +712,10 @@ function removeGTCEURecipes(event) {
 
 	event.remove({ id: 'minecraft:ender_eye' })
 
+	// Remove GTceu Sticky Resin Centrifuge recipe
+
+	event.remove({ id: 'gtceu:centrifuge/sticky_resin_separation' })
+
 	// Remove old treated plank and wood plank recipe
 
 	event.remove({ id: 'gtceu:compressor/compress_plate_dust_wood' })

--- a/kubejs/server_scripts/tfg/recipes.food.js
+++ b/kubejs/server_scripts/tfg/recipes.food.js
@@ -359,7 +359,7 @@ function registerTFGFoodRecipes(event) {
 			circuit: 6,
 			itemInputs: [item],
 			itemOutputs: [item],
-			fluidInputs: [Fluid.of('gtceu:wood_gas', 50)],
+			fluidInputs: [Fluid.of('gtceu:wood_gas', 5)],
 			itemOutputProvider: TFC.isp.copyInput().addTrait("firmalife:smoked")
 		})
 	})

--- a/kubejs/server_scripts/tfg/recipes.miscellaneous.js
+++ b/kubejs/server_scripts/tfg/recipes.miscellaneous.js
@@ -48,7 +48,7 @@ function registerTFGMiscellaneousRecipes(event) {
 		.inputFluids(Fluid.of('tfg:conifer_pitch', 1000))
 		.itemInputs('tfc:powder/charcoal')
 		.itemOutputs('tfg:conifer_rosin')
-		.duration(20*24)
+		.duration(20*12)
 		.EUt(GTValues.VA[GTValues.LV])
 
 	// Decorative Vases


### PR DESCRIPTION
-Add uniformisation for all the resins (Extractor, etc...)
-Nerf the Centrifuge of logs to MV so players have to make the LV Line
-Buff the LV line so it's faster
-Make Sticky resins and glue faster
-Change the centrifuge of Sticker Resin and Rosin into glue to be faster and increase biomass output
-Alternative recipe with extractor faster if needed

-Balance the wood gas

Do we keep wood gas for smoked food or change for a wood dust as an item?