### PR TITLE
Fix Pyrolyse Oven accepting other ender pearls

### DIFF
--- a/kubejs/server_scripts/tfg/recipes.miscellaneous.js
+++ b/kubejs/server_scripts/tfg/recipes.miscellaneous.js
@@ -662,7 +662,7 @@ function registerTFGMiscellaneousRecipes(event) {
 		.EUt(GTValues.VA[GTValues.HV])
 
 	event.recipes.gtceu.pyrolyse_oven('vitrified_ender_dust')
-		.itemInputs('#forge:ender_pearls', '2x tfc:powder/kaolinite', '4x #forge:insulation_t1')
+		.itemInputs('minecraft:ender_pearl', '2x tfc:powder/kaolinite', '4x #forge:insulation_t1')
 		.inputFluids(Fluid.of('gtceu:nitrogen', 100))
 		.itemOutputs('tfg:vitrified_pearl')
 		.chancedOutput('gtceu:ash_dust', 2500, 0)


### PR DESCRIPTION
You should have to make an Implosion Compressor and not skip by killing Enderman