### PR TITLE
Fixed Moon Light Level for Spawning

### DIFF
--- a/kubejs/data/tfg/dimension_type/moon.json
+++ b/kubejs/data/tfg/dimension_type/moon.json
@@ -10,7 +10,7 @@
 	"infiniburn": "#minecraft:infiniburn_overworld",
 	"logical_height": 384,
 	"min_y": 0,
-	"monster_spawn_block_light_limit": 15,
+	"monster_spawn_block_light_limit": 0,
 	"monster_spawn_light_level": {
 		"type": "minecraft:uniform",
 		"value": {


### PR DESCRIPTION
Moon Needed a light level of 12 or higher to stop ad astra mobs from spawning

I changed 1 line

## Outcome
Fixes #1587 
Tested in singleplayer.


Discord: NINAustinFett

