### PR TITLE
fix: Fixed quests.metal_age.redblu_anvil requirements

### DIFF
--- a/config/ftbquests/quests/chapters/questsmetallurgy.snbt
+++ b/config/ftbquests/quests/chapters/questsmetallurgy.snbt
@@ -661,6 +661,7 @@
 				"5088768AAA28FCBA"
 				"6D04BAC5B215F90F"
 			]
+			dependency_requirement: "one_completed"
 			description: ["{quests.metal_age.redblu_anvil.desc}"]
 			id: "56CA2EB7812529C5"
 			shape: "octagon"


### PR DESCRIPTION
## What is the new behavior?
`quests.metal_age.redblu_anvil` has both red and blue steel requirements, however it seems more logical if only one is required as only one of both anvils is required

## Implementation Details
added `dependency_requirement: "one_completed"`

## Outcome
Only one of both paths is requried

## Additional Information
None

## Potential Compatibility Issues
None