### PR TITLE
fix: Fixed quests.metal_age.red_blu

### DIFF
--- a/config/ftbquests/quests/chapters/questsmetallurgy.snbt
+++ b/config/ftbquests/quests/chapters/questsmetallurgy.snbt
@@ -630,11 +630,9 @@
 			id: "5792DDAA82895E67"
 			subtitle: "{quests.metal_age.red_blu.subtitle}"
 			tasks: [{
-				dimension: "minecraft:overworld"
-				icon: "gtceu:overworld_marker"
-				id: "720D64916D1E3892"
-				title: "{quests.stone_age.temperature.task}"
-				type: "dimension"
+				id: "63890641DCD6659F"
+				title: "{quests.tasktype.checkmark}"
+				type: "checkmark"
 			}]
 			title: "{quests.metal_age.red_blu.title}"
 			x: 24.0d


### PR DESCRIPTION
## What is the new behavior?
`quests.metal_age.red_blu` does work on a new worls, but when i imported my save from a previous version it was stuck. Having a checkmark guarantees that it will not be stuck

## Implementation Details
Changed exist task with checkbox

## Outcome
The quest/task is now guaranteed to be completable, as the automatic exist task didn't work as expected on existing saves that were migrated.

## Additional Information
None

## Potential Compatibility Issues
None