### PR TITLE
Fix link in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -56,7 +56,7 @@ This modpack is still a work in progress, and is constantly being updated. In it
 
 Interested in contributing? For detailed setup instructions, coding standards, and guidelines, please read [this](CONTRIBUTING.md).
 
-Want to help translate? Please read [this](../kubejs/README%20IF%20TRANSLATING.md) instead.
+Want to help translate? Please read [this](../kubejs/README_IF_TRANSLATING.md) instead.
 
 ---
 


### PR DESCRIPTION
Fixed a broken link to README_IF_TRANSLATING.md in README.md The file was renamed earlier, but the link has not been changed