### PR TITLE
fix semiheavy concurrent with tfg core

### DIFF
--- a/kubejs/data/tfg/worldgen/configured_feature/mars/semiheavy_ammoniacal_water.json
+++ b/kubejs/data/tfg/worldgen/configured_feature/mars/semiheavy_ammoniacal_water.json
@@ -1,7 +1,7 @@
 {
 	"type": "tfc:flood_fill_lake",
 	"config": {
-		"state": "tfg:semiheavy_ammoniacal_water",
+		"state": "tfg:fluid/semiheavy_ammoniacal_water",
 		"replace_fluids": [],
 		"overfill": true
 	}

--- a/kubejs/data/tfg/worldgen/noise_settings/mars_noise.json
+++ b/kubejs/data/tfg/worldgen/noise_settings/mars_noise.json
@@ -8,7 +8,7 @@
 		"Name": "ad_astra:mars_stone"
 	},
 	"default_fluid": {
-		"Name": "tfg:semiheavy_ammoniacal_water"
+		"Name": "tfg:fluid/semiheavy_ammoniacal_water"
 	},
 	"noise": {
 		"min_y": -32,


### PR DESCRIPTION
## What is the new behavior?
semiheavy ammoniacal water block now has the correct tag

## Outcome
maps show the right color
See https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/111

