### PR TITLE
Hot Bread Fixes

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -183,6 +183,9 @@ const registerTFCRecipes = (event) => {
 	event.recipes.tfc.heating('tfc:plant/winged_kelp', 200)
 		.resultItem('tfc:food/dried_kelp')
 
+	// Burning Bread
+	event.recipes.tfc.heating('#tfc:foods/breads', 850)
+
 	// Soda Ash
 	event.smelting('3x tfc:powder/soda_ash', 'tfc:food/dried_seaweed').id('tfg:smelting/dried_seaweed_to_soda')
 	event.smelting('3x tfc:powder/soda_ash', 'tfc:food/dried_kelp').id('tfg:smelting/dried_kelp_to_soda')

--- a/kubejs/server_scripts/tfc/recipes.removes.js
+++ b/kubejs/server_scripts/tfc/recipes.removes.js
@@ -153,6 +153,7 @@ function removeTFCRecipes(event) {
 	event.remove({ id: 'tfc:crafting/alabaster_brick' })
 
 	event.remove({ id: /^tfc:crafting\/dough\/.*/ })
+	event.remove({ id: 'tfc:heating/destroy_bread' })
 
 	event.remove({ id: 'tfc:crafting/gunpowder_graphite' })
 	event.remove({ id: 'tfc:crafting/gunpowder' })


### PR DESCRIPTION
Firmalife ovens are a bit weird, in that they instantly heat the result of a baking recipe to the oven's temperature, even if it is uninsulated and can only heat food half as hot as normal. This results in some logs, such as mahogany or hickory, causing bread to heat to Bright Red when cooked. There is a TFC recipe for burning bread when it gets above a certain heat, which is what causes the bread to sometimes vanish when held after removing it from the oven. 
I have increased the temperature required to burn bread up to Bright Red**, or 850 degrees, in order to circumvent this problem. Bread can still be burned if heated with stick bundles or charcoal, but will no longer burn when heated with normal logs. This quality of life change should help reduce confusion around disappearing bread, since the actual mechanics of baking bread via oven are already confusing enough.