### PR TITLE
added forge:cobblestone to facade_materials

### DIFF
--- a/kubejs/server_scripts/tfg/tags.facades.js
+++ b/kubejs/server_scripts/tfg/tags.facades.js
@@ -28,6 +28,7 @@ function registerFacadeWhitelistTags(event) {
 		'#simplylight:any_lamp_off',
 		'#minecraft:planks',
 		'#minecraft:logs',
+		'#forge:cobblestone',
 
 		'#tfg:ad_astra_iron_blocks',
 		'#tfg:ad_astra_steel_blocks',


### PR DESCRIPTION
## What is the new behavior?
add all cobblestone to be used as facades

## Implementation Details
added `forge:cobblestone` to the `facade_materials` list


## Outcome
Cobblestone to be valid option to make into facades.

## Additional Information
i noticed every other material is tagged as `#tfc/rock/x` with x being something like "bricks" or "smooth" yet none of the cobblestone follows this tag structure, i'm unsure if this is intentional, so I have used forge:cobblestone to add it all to the facade list.

## Potential Compatibility Issues
none that i can think of