### PR TITLE
melting recipe fixes

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.materials.js
+++ b/kubejs/server_scripts/tfc/recipes.materials.js
@@ -731,6 +731,26 @@ function registerTFCMaterialsRecipes(event) {
 					.tier(tfcProperty.getTier())
 					.id(`gtceu:anvil/${material.getName()}_wrench_tip`)
 				//#endregion
+
+				//#region crowbar
+				let crowbarItem = ToolHelper.get(GTToolType.CROWBAR, material)
+				if (!crowbarItem.isEmpty()) {
+					event.recipes.tfc.heating(crowbarItem, tfcProperty.getMeltTemp())
+						.resultFluid(Fluid.of(outputMaterial.getFluid(), 216))
+						.useDurability(true)
+						.id(`gtceu:heating/metal/${material.getName()}_crowbar`)
+				}
+				//#endregion
+
+				//#region mortar
+				let mortarItem = ToolHelper.get(GTToolType.MORTAR, material)
+				if (!mortarItem.isEmpty()) {
+					event.recipes.tfc.heating(mortarItem, tfcProperty.getMeltTemp())
+						.resultFluid(Fluid.of(outputMaterial.getFluid(), 144))
+						.useDurability(true)
+						.id(`gtceu:heating/metal/${material.getName()}_mortar`)
+				}
+				//#endregion
 				
 				//#region wire cutters
 				event.recipes.tfc.heating(`gtceu:${material.getName()}_wire_cutter`, tfcProperty.getMeltTemp())


### PR DESCRIPTION
## What is the new behavior?
Fixes #1831 

Adds heating recipes for the Mortar and Crowbar. Crowbar melts into 216 mB of the tools material, 
Mortar melts into 144 mB of the tools material.

## Implementation Details
For each material that has a GT tool, look up tool item with ToolHelper.get(GTToolType.CROWBAR, material) (or MORTAR), matching the existing KubeJS code, then registers it.

## Outcome
Fixes #1831 
Allows melting of Mortar and Crowbar to their base materals.

## Additional Information
EMI shows it, amount you get back matches your durability.


## Potential Compatibility Issues
None!

Newlumberjack