### PR TITLE
Create packager recipe buffs

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1732,12 +1732,6 @@ const registerCreateRecipes = (event) => {
 		F: '#tfg:metal_bars'
 	}).id('tfg:create/shaped/packager')
 
-	event.recipes.gtceu.assembler('tfg:create/packager')
-		.itemInputs('gtceu:ulv_machine_casing', '4x #forge:rods/wrought_iron', '#forge:springs/wrought_iron', '4x create:cardboard', '#gtceu:circuits/ulv')
-		.itemOutputs('2x create:packager')
-		.duration(200)
-		.EUt(20)
-
 	event.shaped('create:item_hatch', [
 		'A',
 		'B',

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1712,8 +1712,8 @@ const registerCreateRecipes = (event) => {
 	}).id('tfg:create/shaped/cardboard_from_glue')
 
 	event.recipes.gtceu.assembler('tfg:create/cardboard_from_glue')
-		.itemInputs('5x minecraft:paper')
-		.inputFluids(Fluid.of('gtceu:glue', 100))
+		.itemInputs('4x minecraft:paper')
+		.inputFluids(Fluid.of('gtceu:glue', 50))
 		.circuit(5)
 		.itemOutputs('2x create:cardboard')
 		.duration(200)
@@ -1726,14 +1726,14 @@ const registerCreateRecipes = (event) => {
 	], {
 		A: '#forge:rods/wrought_iron',
 		B: '#forge:springs/wrought_iron',
-		C: 'gtceu:ulv_machine_hull',
+		C: 'create:andesite_casing',
 		D: 'create:bound_cardboard_block',
 		E: 'create:electron_tube',
 		F: '#tfg:metal_bars'
 	}).id('tfg:create/shaped/packager')
 
 	event.recipes.gtceu.assembler('tfg:create/packager')
-		.itemInputs('gtceu:ulv_machine_hull', '4x #forge:rods/wrought_iron', '#forge:springs/wrought_iron', '4x create:cardboard', '#forge:string', '#gtceu:circuits/ulv')
+		.itemInputs('create:andesite_casing', '4x #forge:rods/wrought_iron', '#forge:springs/wrought_iron', '4x create:cardboard', '#gtceu:circuits/ulv')
 		.itemOutputs('create:packager')
 		.duration(200)
 		.EUt(20)

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1719,22 +1719,22 @@ const registerCreateRecipes = (event) => {
 		.duration(200)
 		.EUt(7)
 
-	event.shaped('create:packager', [
+	event.shaped('2x create:packager', [
 		'AAA',
 		'BCD',
 		'EFE'
 	], {
 		A: '#forge:rods/wrought_iron',
 		B: '#forge:springs/wrought_iron',
-		C: 'create:andesite_casing',
+		C: 'gtceu:ulv_machine_casing',
 		D: 'create:bound_cardboard_block',
 		E: 'create:electron_tube',
 		F: '#tfg:metal_bars'
 	}).id('tfg:create/shaped/packager')
 
 	event.recipes.gtceu.assembler('tfg:create/packager')
-		.itemInputs('create:andesite_casing', '4x #forge:rods/wrought_iron', '#forge:springs/wrought_iron', '4x create:cardboard', '#gtceu:circuits/ulv')
-		.itemOutputs('create:packager')
+		.itemInputs('gtceu:ulv_machine_casing', '4x #forge:rods/wrought_iron', '#forge:springs/wrought_iron', '4x create:cardboard', '#gtceu:circuits/ulv')
+		.itemOutputs('2x create:packager')
 		.duration(200)
 		.EUt(20)
 

--- a/kubejs/server_scripts/create_factory_logistics/recipes.js
+++ b/kubejs/server_scripts/create_factory_logistics/recipes.js
@@ -28,17 +28,18 @@ function registerCreateFactoryLogisticsRecipes(event) {
 	], {
 		A: '#forge:rods/copper',
 		B: '#forge:springs/copper',
-		C: 'gtceu:ulv_machine_hull',
+		C: 'create:andesite_casing',
 		D: 'create:fluid_tank',
 		E: 'create:electron_tube',
 		F: '#tfg:metal_bars'
 	}).id('create_factory_logistics:shaped/jar_packager')
 
 	event.recipes.gtceu.assembler('create_factory_logistics:jar_packager')
-		.itemInputs('gtceu:ulv_machine_hull', '4x #forge:rods/copper', '#forge:springs/copper', 'create:fluid_tank', '#gtceu:circuits/ulv')
+		.itemInputs('create:andesite_casing', '4x #forge:rods/copper', '#forge:springs/copper', 'create:fluid_tank', '#gtceu:circuits/ulv')
 		.itemOutputs('create_factory_logistics:jar_packager')
 		.duration(200)
 		.EUt(20)
+		
 
 	event.shapeless('create_factory_logistics:factory_fluid_gauge', ['create_factory_logistics:factory_fluid_gauge'])
 		.id('create_factory_logistics:shapeless/factory_fluid_gauge_clear')

--- a/kubejs/server_scripts/create_factory_logistics/recipes.js
+++ b/kubejs/server_scripts/create_factory_logistics/recipes.js
@@ -34,13 +34,7 @@ function registerCreateFactoryLogisticsRecipes(event) {
 		F: '#tfg:metal_bars'
 	}).id('create_factory_logistics:shaped/jar_packager')
 
-	event.recipes.gtceu.assembler('create_factory_logistics:jar_packager')
-		.itemInputs('gtceu:ulv_machine_casing', '4x #forge:rods/copper', '#forge:springs/copper', 'create:fluid_tank', '#gtceu:circuits/ulv')
-		.itemOutputs('2x create_factory_logistics:jar_packager')
-		.duration(200)
-		.EUt(20)
 		
-
 	event.shapeless('create_factory_logistics:factory_fluid_gauge', ['create_factory_logistics:factory_fluid_gauge'])
 		.id('create_factory_logistics:shapeless/factory_fluid_gauge_clear')
 

--- a/kubejs/server_scripts/create_factory_logistics/recipes.js
+++ b/kubejs/server_scripts/create_factory_logistics/recipes.js
@@ -21,22 +21,22 @@ function registerCreateFactoryLogisticsRecipes(event) {
 		.EUt(20)
 
 
-	event.shaped('create_factory_logistics:jar_packager', [
+	event.shaped('2x create_factory_logistics:jar_packager', [
 		'AAA',
 		'BCD',
 		'EFE'
 	], {
 		A: '#forge:rods/copper',
 		B: '#forge:springs/copper',
-		C: 'create:andesite_casing',
+		C: 'gtceu:ulv_machine_casing',
 		D: 'create:fluid_tank',
 		E: 'create:electron_tube',
 		F: '#tfg:metal_bars'
 	}).id('create_factory_logistics:shaped/jar_packager')
 
 	event.recipes.gtceu.assembler('create_factory_logistics:jar_packager')
-		.itemInputs('create:andesite_casing', '4x #forge:rods/copper', '#forge:springs/copper', 'create:fluid_tank', '#gtceu:circuits/ulv')
-		.itemOutputs('create_factory_logistics:jar_packager')
+		.itemInputs('gtceu:ulv_machine_casing', '4x #forge:rods/copper', '#forge:springs/copper', 'create:fluid_tank', '#gtceu:circuits/ulv')
+		.itemOutputs('2x create_factory_logistics:jar_packager')
 		.duration(200)
 		.EUt(20)
 		


### PR DESCRIPTION
## What is the new behavior?
Packagers and Bottlers have their costs reduced by making them require metal casings rather than ULV Hulls.

## Implementation Details
Playing TFG with my friends we found out that the ULV hulls that are part of the packager/bottler recipes are prohibitively expensive, especially early game. With them being so crucial to the setting up of a logistics network, this PR addresses that by making the recipe require a casing rather than a hull (remove rubber dependency) and giving 2x returns for the crafts.

Additionally, the LV assembler cardboard recipe has also been buffed a bit to require less paper and glue because it's a tedious recipe to begin with. This should make it a lot less annoying to make.

Stock links/factory gauge recipes are left unchanged, as the automation of parts needed in them is a core mechanic of LV/MV and they will naturally become less tedious to craft as an LV/MV factory expands

Original PR proposed replacing the most expensive part of these recipes with metal (andesite) casings, cutting down the wrought iron usage to nearly 10% of the original cost, before it was revised to current state.

## Outcome
Changes the recipes for the create Packager, create factory logistics Bottler, and cardboard in the LV assembler. 
Overall this should make these feel better to craft.

## Potential Compatibility Issues
N/A