### PR TITLE
rebalance sns hiking boots

### DIFF
--- a/defaultconfigs/sns-server.toml
+++ b/defaultconfigs/sns-server.toml
@@ -187,7 +187,7 @@
 	["Boot config"."Blue Steel Toe Boots"]
 		#The movement speed bonus these boots provide
 		#Range: 0.0 ~ 1024.0
-		movementSpeed = 0.2
+		movementSpeed = 0.25
 		#The step height bonus these boots provide
 		#Range: 0.0 ~ 512.0
 		stepHeight = 0.5
@@ -197,7 +197,7 @@
 		#The amount of 'steps' taken before one point of durability is lost
 		#Steps are defined as being any change in position while grounded between ticks (IE over 1 second 20 'steps' occur)
 		#Range: > 0
-		stepsPerDamage = 4000
+		stepsPerDamage = 2500
 
 	["Boot config"."Red Steel Toe Boots"]
 		#The movement speed bonus these boots provide

--- a/kubejs/startup_scripts/main_startup_script.js
+++ b/kubejs/startup_scripts/main_startup_script.js
@@ -27,6 +27,7 @@ ItemEvents.modification(event => {
 	registerFirmalifeItemModifications(event)
 	registerGTCEuItemModifications(event)
 	registerMinecraftItemModifications(event)
+    registerSNSItemModifications(event)
 })
 
 StartupEvents.registry('fluid', event => {

--- a/kubejs/startup_scripts/sacksnsuch/modifications.js
+++ b/kubejs/startup_scripts/sacksnsuch/modifications.js
@@ -1,0 +1,23 @@
+"use strict";
+
+function registerSNSItemModifications(event) {
+    const bootPairs = [
+        // [hiking_boot, non-hiking_equivalent]
+        ['sns:hiking_boots', 'minecraft:leather_boots'],
+        ['sns:steel_toe_hiking_boots', 'tfc:metal/boots/steel'],
+        ['sns:black_steel_toe_hiking_boots', 'tfc:metal/boots/black_steel'],
+        ['sns:blue_steel_toe_hiking_boots', 'tfc:metal/boots/blue_steel'],
+        ['sns:red_steel_toe_hiking_boots', 'tfc:metal/boots/red_steel']
+    ]
+
+    // for each pair, set the max damage of the hiking boot to 10% more than the normal boot
+    bootPairs.forEach(pair => {
+        const hikingBoot = pair[0]
+        const normalBoot = pair[1]
+
+        event.modify(hikingBoot, item => {
+            item.maxDamage = Item.of(normalBoot).maxDamage * 1.1
+        })
+    })
+}
+


### PR DESCRIPTION
## What is the new behavior?

Hiking boots durability are now 10% more then their non-hiking equivalent - mostly to compensate for the additional cost.
Blue hiking boots are now the fastest at a 0.25 modifier while Red hiking boots have the lowest wear from walking to match the existing design of red steel being more durable and blue steel being more utility.

## Implementation Details
should be easy enough to understand, array to add new boots easily, 

`[hiking boot, non-hiking equivalent]`

will set the maxDamage of `hiking boot` to the maxDamage of `non-hiking equivalent` multiplied by 1.1


## Outcome
Hiking boots have a more fair life span, my group found that we would be burning through 3 sets between us in a few irl days, while a full set of Armour of equivalent tier will last SIGNIFICANTLY longer

## Additional Information
I'm open to any feedback, but i feel the boost is fair considering the additional cost of reinforced fiber, buckles, additional plates. If anything I'd be open to increasing the modifier to 1.25.