### PR TITLE
Switched tfg:sugars for tfc:sweetener in food processor jam recipes

### DIFF
--- a/kubejs/server_scripts/tfg/recipes.food.js
+++ b/kubejs/server_scripts/tfg/recipes.food.js
@@ -469,7 +469,7 @@ function registerTFGFoodRecipes(event) {
 	global.TFC_JAMS.forEach(name => {
 		processorRecipe(`${name}_jam`, 200, 8, {
 			circuit: 15,
-			itemInputs: [`4x tfc:food/${name}`, "#tfg:sugars", "4x #tfc:empty_jar_with_lid"],
+			itemInputs: [`4x tfc:food/${name}`, "#tfc:sweetener", "4x #tfc:empty_jar_with_lid"],
 			fluidInputs: ['#tfg:clean_water 100'],
 			itemOutputs: [`4x tfc:jar/${name}`],
 			itemOutputProvider: TFC.isp.of(`4x tfc:jar/${name}`).copyFood()
@@ -477,7 +477,7 @@ function registerTFGFoodRecipes(event) {
 
 		processorRecipe(`${name}_jam_no_seal`, 200, 8, {
 			circuit: 16,
-			itemInputs: [`4x tfc:food/${name}`, "#tfg:sugars", "4x tfc:empty_jar"],
+			itemInputs: [`4x tfc:food/${name}`, "#tfc:sweetener", "4x tfc:empty_jar"],
 			fluidInputs: ['#tfg:clean_water 100'],
 			itemOutputs: [`4x tfc:jar/${name}_unsealed`],
 			itemOutputProvider: TFC.isp.of(`4x tfc:jar/${name}_unsealed`).copyFood()
@@ -487,7 +487,7 @@ function registerTFGFoodRecipes(event) {
 	global.FIRMALIFE_JAMS.forEach(name => {
 		processorRecipe(`${name}_jam`, 200, 8, {
 			circuit: 15,
-			itemInputs: [`4x firmalife:food/${name}`, "#tfg:sugars", "4x #tfc:empty_jar_with_lid"],
+			itemInputs: [`4x firmalife:food/${name}`, "#tfc:sweetener", "4x #tfc:empty_jar_with_lid"],
 			fluidInputs: ['#tfg:clean_water 100'],
 			itemOutputs: [`4x firmalife:jar/${name}`],
 			itemOutputProvider: TFC.isp.of(`4x firmalife:jar/${name}`).copyFood()
@@ -495,7 +495,7 @@ function registerTFGFoodRecipes(event) {
 
 		processorRecipe(`${name}_jam_no_seal`, 200, 8, {
 			circuit: 16,
-			itemInputs: [`4x firmalife:food/${name}`, "#tfg:sugars", "4x tfc:empty_jar"],
+			itemInputs: [`4x firmalife:food/${name}`, "#tfc:sweetener", "4x tfc:empty_jar"],
 			fluidInputs: ['#tfg:clean_water 100'],
 			itemOutputs: [`4x firmalife:jar/${name}_unsealed`],
 			itemOutputProvider: TFC.isp.of(`4x firmalife:jar/${name}_unsealed`).copyFood()


### PR DESCRIPTION
## What is the new behavior?
The Food Processor recipe for Jam uses the tfc:sweetener tag now, allowing for making jam with honey in the food processor now.

## Implementation Details
Edited the recipes.food.js file and changed the food processor jam recipes to use tfc:sweetener instead of tfg:sugars

## Outcome
Honey can now be used to make jam in the food processor, just like in a vat (sugar water can be made with any tfc:sweetener)

**Discord: xaligal**