### PR TITLE
Bugfix/fix birch and maple sugar recipe conflict

### DIFF
--- a/kubejs/assets/tfg/lang/en_us.json
+++ b/kubejs/assets/tfg/lang/en_us.json
@@ -1369,6 +1369,8 @@
   "tfc.recipe.barrel.tfg.sealed_barrel.prepared_leather_gloves": "Soaking Leather Gloves",
   "tfc.recipe.barrel.tfg.barrel.rapeseed_to_oil": "Extracting Canola Oil",
   "tfc.recipe.barrel.tfg.barrel.sunflower_to_oil": "Extracting Sunflower Oil",
+  "tfc.recipe.barrel.tfg.barrel.maple_syrup_to_sugar": "Making sugar",
+  "tfc.recipe.barrel.tfg.barrel.birch_syrup_to_sugar": "Making sugar",
   "gtceu.aqueous_accumulator": "Aqueous Accumulator",
   "tfg.food_recipe.brining": "Brining",
   "tfg.food_recipe.smoking": "Smoking",

--- a/kubejs/assets/tfg/lang/en_us.json
+++ b/kubejs/assets/tfg/lang/en_us.json
@@ -1369,8 +1369,6 @@
   "tfc.recipe.barrel.tfg.sealed_barrel.prepared_leather_gloves": "Soaking Leather Gloves",
   "tfc.recipe.barrel.tfg.barrel.rapeseed_to_oil": "Extracting Canola Oil",
   "tfc.recipe.barrel.tfg.barrel.sunflower_to_oil": "Extracting Sunflower Oil",
-  "tfc.recipe.barrel.tfg.barrel.maple_syrup_to_sugar": "Making sugar",
-  "tfc.recipe.barrel.tfg.barrel.birch_syrup_to_sugar": "Making sugar",
   "gtceu.aqueous_accumulator": "Aqueous Accumulator",
   "tfg.food_recipe.brining": "Brining",
   "tfg.food_recipe.smoking": "Smoking",

--- a/kubejs/server_scripts/afc/recipes.js
+++ b/kubejs/server_scripts/afc/recipes.js
@@ -371,6 +371,20 @@ const registerAFCRecipes = (event) => {
 		.duration(20*12)
 		.EUt(GTValues.VHA[GTValues.ULV])
 
+
+	// Syrup into sugar
+
+	event.recipes.tfc.barrel_sealed(24000)
+	.inputFluid(Fluid.of('afc:maple_syrup', 100))
+	.outputItem('afc:maple_sugar')
+	.id('tfg:barrel/maple_syrup_to_sugar')
+
+	event.recipes.tfc.barrel_sealed(24000)
+	.inputFluid(Fluid.of('afc:birch_syrup', 100))
+	.outputItem('afc:birch_sugar')
+	.id('tfg:barrel/birch_syrup_to_sugar')
+
+
 	// Stripped logs
 
 	global.AFC_WOOD_TYPES.forEach(wood => {

--- a/kubejs/server_scripts/afc/recipes.js
+++ b/kubejs/server_scripts/afc/recipes.js
@@ -16,6 +16,11 @@ const registerAFCRecipes = (event) => {
 	event.remove({ id: "afc:pot/rubber" })
 	event.remove({ id: "afc:tree_tapping/hevea_latex" })
 	event.remove({ id: "afc:tree_tapping/rubber_fig_latex" })
+	event.remove({ id: "afc:crafting/1_birch_sugar"})
+	event.remove({ id: "afc:crafting/1_maple_sugar"})
+	event.remove({ id: "afc:crafting/0_birch_sugar_bucket"})
+	event.remove({ id: "afc:crafting/0_maple_sugar_bucket"})
+
 
 	// #endregion
 


### PR DESCRIPTION
## What is the new behavior?
Changed recipe for making birch/maple sugar.

## Implementation Details
Removes the recipes for turning buckets/bottles and other fluid containers filled with birch/maple syrup into birch/maple sugar.
Adds a sealed barrel recipe for turning  syrup into sugar.

## Outcome
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/1914
Can no longer craft birch/maple sugar directly which had a buggy recipe.
Now you can turn 100mb of birch/maple syrup into 1x birch/maple sugar via a sealed barrel recipe which takes 24 minutes(1 day).


## Additional Information
<img width="692" height="293" alt="image" src="https://github.com/user-attachments/assets/52df9c8b-df59-40c0-9e3a-5c886f732b9e" />

<img width="691" height="298" alt="image" src="https://github.com/user-attachments/assets/6ff23dad-bb2f-489e-96c1-076ffda800c4" />

## Potential Compatibility Issues
Dont' think so.

Johannesbröd