### PR TITLE
buffed treated stick lathe recipe (#4629)

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -493,8 +493,5 @@ const registerGTCEURecipes = (event) => {
 
 	//Buff treated wood stick output for lathe
 
-	global.modifyRecipe(event, "gtceu:lathe/treated_wood_sticks", {
-		newId: "tfg:treated_planks_to_sticks",
-		itemOutputs: { "gtceu:treated_wood_rod": 8 }
-	})
+	event.replaceOutput({id: 'gtceu:lathe/treated_wood_sticks'}, 'gtceu:treated_wood_rod', '8x gtceu:treated_wood_rod')
 }

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -490,4 +490,11 @@ const registerGTCEURecipes = (event) => {
 		.chancedOutput(Item.of('gtceu:neodymium_dust', 1), 2000, 0)
 		.duration(2.5*20)
 		.EUt(GTValues.VA[GTValues.MV])
+
+	//Buff treated wood stick output for lathe
+
+	global.modifyRecipe(event, "gtceu:lathe/treated_wood_sticks", {
+		newId: "tfg:treated_planks_to_sticks",
+		itemOutputs: { "gtceu:treated_wood_rod": 8 }
+	})
 }


### PR DESCRIPTION

## What is the new behavior?
Buffed treated stick output to be in line with other lathe stick recipes.
Issue: https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4629

## Implementation Details
Lathe output modified from 2 to 8 treated sticks when using a lathe on treated wood planks. inputs and energy requirements unchanged.

## Outcome
lathe now produces 8 sticks
<img width="362" height="286" alt="image" src="https://github.com/user-attachments/assets/e65035fe-f4fa-4198-b6e8-3d3b87ae7799" />

Discord: GlassHound