### PR TITLE
Removed tracks spam and higher GT tiers (UHV+)

### DIFF
--- a/.github/config/extract_lang.json
+++ b/.github/config/extract_lang.json
@@ -135,6 +135,7 @@
     "block\\.gtceu\\.lp_.*",
     "(item|block)\\.gtceu\\.(opv|uev|uiv|uxv).*",
     "block\\.mcw_tfc_aio\\..*_railing_gate",
-    "(item|block)\\.railways\\.track_(?!tfc_|incomplete_tfc_)",
+    "(item|block)\\.railways\\.(track_incomplete|track)_(byg|biomesoplenty|blue_skies|hexcasting|natures|quark|twilightforest|create_dd).*",
+    "(item|block)\\.railways\\.(track_incomplete|track)_(dark_oak|oak|mangrove|ender)(_narrow|_wide)?"
   ]
 }

--- a/.github/config/extract_lang.json
+++ b/.github/config/extract_lang.json
@@ -133,6 +133,8 @@
     "(item|entity)\\.tfcastikorcarts\\.(plow|animal_cart|supply_cart|wheel)\\.(african_padauk|alder|angelim|argyle_eucalyptus|bald_cypress|baobab|beech|black_walnut|black_willow|brazilwood|butternut|buxus|cocobolo|common_oak|cypress|ebony|fever|ghaf|ginkgo|greenheart|hawthorn|hazel|hemlock|holly|hornbeam|iroko|ironwood|jabuticabeira|joshua|juniper|kauri|larch|laurel|limba|locust|logwood|maclura|mahoe|mahogany|marblewood|medlar|messmate|mountain_ash|mulberry|nordmann_fir|norway_spruce|pear|persimmon|pink_cherry_blossom|pink_ipe|pink_ivory|poplar|purple_ipe|purple_jacaranda|purpleheart|quince|rainbow_eucalyptus|red_cedar|red_cypress|red_elm|red_mangrove|redwood|rowan|rubber_fig|sloe|snow_gum_eucalyptus|sorb|sweetgum|syzygium|teak|walnut|wenge|white_cherry_blossom|white_elm|white_ipe|white_jacaranda|white_mangrove|whitebeam|yellow_ipe|yellow_jacaranda|yellow_meranti|yew|zebrawood)",
     "block\\.tfc\\.ore\\..*\\.prospected",
     "block\\.gtceu\\.lp_.*",
-    "block\\.mcw_tfc_aio\\..*_railing_gate"
+    "(item|block)\\.gtceu\\.(opv|uev|uiv|uxv).*",
+    "block\\.mcw_tfc_aio\\..*_railing_gate",
+    "(item|block)\\.railways\\.track_(?!tfc_|incomplete_tfc_)",
   ]
 }


### PR DESCRIPTION
Removed train tracks spam and higher GT tiers (UHV+) from crowdin localizations. Pyritie said that tiers after UHV won't be used in TFG.