### PR TITLE
ae2 proposals

### DIFF
--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -1295,8 +1295,9 @@ const registerAE2Recipes = (event) => {
 	// Earth
 	event.recipes.gtceu.assembler('ae2:interface_earth')
 		.itemInputs(
-			'gtceu:hv_electric_motor',
+			'gtceu:hv_conveyor_module',
 			'1x gtceu:stainless_steel_crate',
+			'4x #forge:plates/stainless_steel',
 			'4x ae2:annihilation_core',
 			'4x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1308,8 +1309,9 @@ const registerAE2Recipes = (event) => {
 	// MV Moon
 	event.recipes.gtceu.me_assembler('ae2:interface_mv_moon')
 		.itemInputs(
-			'gtceu:mv_electric_motor',
+			'gtceu:mv_conveyor_module',
 			'1x gtceu:aluminium_crate',
+			'2x #forge:plates/aluminium',
 			'1x ae2:annihilation_core',
 			'1x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1323,8 +1325,9 @@ const registerAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:interface_iv_moon')
 		.itemInputs(
-			'gtceu:iv_electric_motor',
+			'gtceu:iv_conveyor_module',
 			'1x gtceu:tungsten_steel_crate',
+			'4x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
 			'2x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144 * 8), Fluid.of('gtceu:argon', 144))
@@ -1341,8 +1344,9 @@ const registerAE2Recipes = (event) => {
 	// Earth
 	event.recipes.gtceu.assembler('ae2:pattern_provider_earth')
 		.itemInputs(
-			'gtceu:hv_conveyor_module',
+			'gtceu:hv_robot_arm',
 			'1x gtceu:stainless_steel_crate',
+			'4x #forge:plates/stainless_steel',
 			'4x ae2:annihilation_core',
 			'4x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1354,8 +1358,9 @@ const registerAE2Recipes = (event) => {
 	// MV Moon
 	event.recipes.gtceu.me_assembler('ae2:pattern_provider_mv_moon')
 		.itemInputs(
-			'gtceu:mv_conveyor_module',
+			'gtceu:mv_robot_arm',
 			'1x gtceu:aluminium_crate',
+			'4x #forge:plates/aluminium',
 			'2x ae2:annihilation_core',
 			'2x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1369,8 +1374,9 @@ const registerAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:pattern_provider_iv_moon')
 		.itemInputs(
-			'gtceu:iv_conveyor_module',
+			'gtceu:iv_robot_arm',
 			'1x gtceu:tungsten_steel_crate',
+			'4x #forge:plates/tungsten_steel',
 			'4x ae2:annihilation_core',
 			'4x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144 * 8), Fluid.of('gtceu:argon', 144))

--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -17,6 +17,10 @@ const registerAE2Recipes = (event) => {
 		], mod: 'ae2'
 	});
 
+	function requiresOxygenation(recipe) {
+		TFGRecipeSchemaBindings.isOxygenated(recipe, true)
+	}
+
 	event.remove({ output: 'ae2:fe_p2p_tunnel' })
 
 	// Cutting knives (for renaming things)
@@ -110,15 +114,15 @@ const registerAE2Recipes = (event) => {
 
 	// Crafting Card
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:crafting_card')
 		.itemInputs('1x ae2:basic_card', '4x ae2:cell_component_16k', '4x #tfc:workbenches')
 		.itemOutputs('ae2:crafting_card')
 		.duration(20*120)
 		.EUt(GTValues.VA[GTValues.IV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.addMaterialInfo(true)
-		.circuit(9)
+		.circuit(9))
 
 	// Redstone Card
 	event.recipes.gtceu.shaped('ae2:redstone_card', [
@@ -600,15 +604,15 @@ const registerAE2Recipes = (event) => {
 		.circuit(8)
 
 	// Dense Energy Cell
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ae2/dense_energy_cell')
 		.itemInputs('8x ae2:energy_cell', '8x gtceu:silver_quadruple_wire', '4x #gtceu:circuits/ev')
 		.itemOutputs('ae2:dense_energy_cell')
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.addMaterialInfo(true)
-		.circuit(9)
+		.circuit(9))
 
 	// Energy Acceptor
 	event.recipes.gtceu.assembler('tfg:ae2/energy_acceptor')
@@ -809,7 +813,6 @@ const registerAE2Recipes = (event) => {
 		.duration(20*20)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(3)
 
 	// Pattern box
@@ -838,6 +841,7 @@ const registerAE2Recipes = (event) => {
 		.addMaterialInfo(true)
 		.circuit(1)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:annihilation_core_moon_cr')
 		.itemInputs(
 			'2x #forge:rods/certus_quartz',
@@ -847,9 +851,8 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('8x ae2:annihilation_core')
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.MV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(2)
+		.circuit(2))
 
 	// Formation Core
 
@@ -866,6 +869,7 @@ const registerAE2Recipes = (event) => {
 		.addMaterialInfo(true)
 		.circuit(1)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:formation_core_moon_cr')
 		.itemInputs(
 			'2x #forge:rods/nether_quartz',
@@ -875,9 +879,8 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('8x ae2:formation_core')
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.MV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(2)
+		.circuit(2))
 
 	// Wireless Crafting Terminal
 	event.recipes.gtceu.assembler('ae2:wireless_crafting_terminal')
@@ -983,6 +986,7 @@ const registerAE2Recipes = (event) => {
 
 	// 64k storage components
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:cell_component_64k')
 		.itemInputs(
 			'2x #gtceu:circuits/iv',
@@ -995,11 +999,11 @@ const registerAE2Recipes = (event) => {
 		.duration(20*240)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(4)
+		.circuit(4))
 
 	// 256k storage components
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:cell_component_256k')
 		.itemInputs(
 			'2x #gtceu:circuits/luv',
@@ -1014,13 +1018,13 @@ const registerAE2Recipes = (event) => {
 		.duration(20*400)
 		.EUt(GTValues.VA[GTValues.IV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(5)
+		.circuit(5))
 
 	//#endregion
 
 	//#region Spatial Components
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:spatial_cell_component_2')
 		.itemInputs(
 			'8x #gtceu:circuits/ev',
@@ -1033,11 +1037,11 @@ const registerAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(1)
+		.circuit(1))
 
 	// 16³ Spatial Component
-	
+
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:spatial_cell_component_16')
 		.itemInputs(
 			'8x #gtceu:circuits/luv',
@@ -1050,11 +1054,11 @@ const registerAE2Recipes = (event) => {
 		.duration(20*120)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(2)
+		.circuit(2))
 
 	// 128³ Spatial Component
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:spatial_cell_component_128')
 		.itemInputs(
 			'8x #gtceu:circuits/zpm',
@@ -1067,8 +1071,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20*240)
 		.EUt(GTValues.VA[GTValues.ZPM])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(3)
+		.circuit(3))
 
 	//#endregion
 
@@ -1112,7 +1115,7 @@ const registerAE2Recipes = (event) => {
 	event.recipes.gtceu.assembler('ae2:storage_bus')
 		.itemInputs(
 			'#ae2:interface',
-			'2x gtceu:mv_electric_piston',
+			'2x gtceu:hv_electric_piston',
 			'#ae2:smart_cable')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
 		.itemOutputs('ae2:storage_bus')
@@ -1126,24 +1129,24 @@ const registerAE2Recipes = (event) => {
 			'1x gtceu:mv_electric_piston',
 			'#ae2:smart_cable')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
-		.itemOutputs('1x ae2:storage_bus')
+		.itemOutputs('ae2:storage_bus')
 		.duration(20*10)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
 		.circuit(1)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:storage_bus_moon_cr')
 		.itemInputs(
-			'#ae2:interface',
+			'8x #ae2:interface',
 			'1x gtceu:ev_electric_piston',
 			'#ae2:smart_cable')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
 		.itemOutputs('8x ae2:storage_bus')
 		.duration(20*60)
-		.EUt(GTValues.VA[GTValues.HV])
+		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(2)
+		.circuit(2))
 
 	// Import Bus
 	event.recipes.gtceu.me_assembler('ae2:import_bus')
@@ -1190,6 +1193,7 @@ const registerAE2Recipes = (event) => {
 		.dimension('ad_astra:moon')
 		.circuit(4)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:crafting_unit_cr')
 		.itemInputs(
 			'ae2:logic_processor',
@@ -1201,9 +1205,8 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('2x ae2:crafting_unit')
 		.duration(20*30)
 		.EUt(GTValues.VA[GTValues.HV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(2)
+		.circuit(2))
 
 	//#region Molecular Assembler
 
@@ -1222,7 +1225,7 @@ const registerAE2Recipes = (event) => {
 		.EUt(GTValues.VA[GTValues.HV])
 		.cleanroom(CleanroomType.CLEANROOM)
 
-	// EV Moon
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:molecular_assembler_hv')
 		.itemInputs(
 			'2x #gtceu:circuits/hv',
@@ -1234,11 +1237,12 @@ const registerAE2Recipes = (event) => {
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
 		.itemOutputs('2x ae2:molecular_assembler')
 		.duration(20*30)
-		.EUt(GTValues.VA[GTValues.EV])
+		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.circuit(1)
+		.circuit(1))
 
 	// EV Moon
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:molecular_assembler_iv')
 		.itemInputs(
 			'2x #gtceu:circuits/ev',
@@ -1252,8 +1256,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.IV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(2)
+		.circuit(2))
 
 	//#endregion
 
@@ -1292,9 +1295,8 @@ const registerAE2Recipes = (event) => {
 	// Earth
 	event.recipes.gtceu.assembler('ae2:interface_earth')
 		.itemInputs(
-			'gtceu:hv_conveyor_module',
+			'gtceu:hv_electric_motor',
 			'1x gtceu:stainless_steel_crate',
-			'4x #forge:plates/stainless_steel',
 			'4x ae2:annihilation_core',
 			'4x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1306,9 +1308,8 @@ const registerAE2Recipes = (event) => {
 	// MV Moon
 	event.recipes.gtceu.me_assembler('ae2:interface_mv_moon')
 		.itemInputs(
-			'gtceu:mv_conveyor_module',
+			'gtceu:mv_electric_motor',
 			'1x gtceu:aluminium_crate',
-			'2x #forge:plates/aluminium',
 			'1x ae2:annihilation_core',
 			'1x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1319,20 +1320,19 @@ const registerAE2Recipes = (event) => {
 		.circuit(1)
 
 	// IV Moon
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:interface_iv_moon')
 		.itemInputs(
-			'gtceu:iv_conveyor_module',
+			'gtceu:iv_electric_motor',
 			'1x gtceu:tungsten_steel_crate',
-			'4x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
 			'2x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144 * 8), Fluid.of('gtceu:argon', 144))
 		.itemOutputs('16x ae2:interface')
 		.duration(20 * 120)
 		.EUt(GTValues.VA[GTValues.HV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(2)
+		.circuit(2))
 
 	//#endregion
 
@@ -1341,9 +1341,8 @@ const registerAE2Recipes = (event) => {
 	// Earth
 	event.recipes.gtceu.assembler('ae2:pattern_provider_earth')
 		.itemInputs(
-			'gtceu:hv_robot_arm',
+			'gtceu:hv_conveyor_module',
 			'1x gtceu:stainless_steel_crate',
-			'4x #forge:plates/stainless_steel',
 			'4x ae2:annihilation_core',
 			'4x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1355,9 +1354,8 @@ const registerAE2Recipes = (event) => {
 	// MV Moon
 	event.recipes.gtceu.me_assembler('ae2:pattern_provider_mv_moon')
 		.itemInputs(
-			'gtceu:mv_robot_arm',
+			'gtceu:mv_conveyor_module',
 			'1x gtceu:aluminium_crate',
-			'4x #forge:plates/aluminium',
 			'2x ae2:annihilation_core',
 			'2x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
@@ -1368,20 +1366,19 @@ const registerAE2Recipes = (event) => {
 		.circuit(3)
 
 	// IV Moon
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:pattern_provider_iv_moon')
 		.itemInputs(
-			'gtceu:iv_robot_arm',
+			'gtceu:iv_conveyor_module',
 			'1x gtceu:tungsten_steel_crate',
-			'4x #forge:plates/tungsten_steel',
 			'4x ae2:annihilation_core',
 			'4x ae2:formation_core')
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144 * 8), Fluid.of('gtceu:argon', 144))
 		.itemOutputs('16x ae2:pattern_provider')
 		.duration(20 * 120)
 		.EUt(GTValues.VA[GTValues.HV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(3)
+		.circuit(3))
 
 	//#endregion
 
@@ -1412,6 +1409,19 @@ const registerAE2Recipes = (event) => {
 		.EUt(1920)
 		.cleanroom(CleanroomType.CLEANROOM)
 
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_item_cell_4k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_4k',
+			'#gtceu:batteries/mv',
+			'ae2:item_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_item_cell_4k')
+		.duration(200)
+		.dimension('ad_astra:moon')
+		.EUt(1920))
+
 	// 16k
 	event.recipes.gtceu.assembler('ae2:portable_item_cell_16k')
 		.itemInputs(
@@ -1425,6 +1435,19 @@ const registerAE2Recipes = (event) => {
 		.EUt(7680)
 		.cleanroom(CleanroomType.CLEANROOM)
 
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_item_cell_16k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_16k',
+			'#gtceu:batteries/mv',
+			'ae2:item_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_item_cell_16k')
+		.duration(200)
+		.dimension('ad_astra:moon')
+		.EUt(7680))
+
 	// 64k
 	event.recipes.gtceu.assembler('ae2:portable_item_cell_64k')
 		.itemInputs(
@@ -1437,6 +1460,19 @@ const registerAE2Recipes = (event) => {
 		.duration(200)
 		.EUt(30720)
 		.cleanroom(CleanroomType.CLEANROOM)
+		
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_item_cell_64k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_64k',
+			'#gtceu:batteries/mv',
+			'ae2:item_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_item_cell_64k')
+		.duration(200)
+		.dimension('ad_astra:moon')
+		.EUt(30720))
 
 	// 256k
 	event.recipes.gtceu.assembler('ae2:portable_item_cell_256k')
@@ -1450,6 +1486,19 @@ const registerAE2Recipes = (event) => {
 		.duration(200)
 		.EUt(122880)
 		.cleanroom(CleanroomType.CLEANROOM)
+
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_item_cell_256k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_256k',
+			'#gtceu:batteries/mv',
+			'ae2:item_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_item_cell_256k')
+		.duration(200)
+		.dimension('ad_astra:moon')
+		.EUt(122880))
 
 	//#endregion
 
@@ -1479,6 +1528,19 @@ const registerAE2Recipes = (event) => {
 		.duration(200)
 		.EUt(1920)
 		.cleanroom(CleanroomType.CLEANROOM)
+		
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_fluid_cell_4k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_4k',
+			'#gtceu:batteries/mv',
+			'ae2:fluid_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_fluid_cell_4k')
+		.duration(200)
+		.EUt(1920)
+		.dimension('ad_astra:moon'))
 
 	// 16k
 	event.recipes.gtceu.assembler('ae2:portable_fluid_cell_16k')
@@ -1493,6 +1555,19 @@ const registerAE2Recipes = (event) => {
 		.EUt(7680)
 		.cleanroom(CleanroomType.CLEANROOM)
 
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_fluid_cell_16k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_16k',
+			'#gtceu:batteries/mv',
+			'ae2:fluid_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_fluid_cell_16k')
+		.duration(200)
+		.EUt(7680)
+		.dimension('ad_astra:moon'))
+
 	// 64k
 	event.recipes.gtceu.assembler('ae2:portable_fluid_cell_64k')
 		.itemInputs(
@@ -1505,6 +1580,19 @@ const registerAE2Recipes = (event) => {
 		.duration(200)
 		.EUt(30720)
 		.cleanroom(CleanroomType.CLEANROOM)
+		
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_fluid_cell_64k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_64k',
+			'#gtceu:batteries/mv',
+			'ae2:fluid_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_fluid_cell_64k')
+		.duration(200)
+		.EUt(30720)
+		.dimension('ad_astra:moon'))
 
 	// 256k
 	event.recipes.gtceu.assembler('ae2:portable_fluid_cell_256k')
@@ -1518,6 +1606,19 @@ const registerAE2Recipes = (event) => {
 		.duration(200)
 		.EUt(122880)
 		.cleanroom(CleanroomType.CLEANROOM)
+
+	requiresOxygenation(
+	event.recipes.gtceu.me_assembler('ae2:portable_fluid_cell_256k')
+		.itemInputs(
+			'ae2:chest',
+			'ae2:cell_component_256k',
+			'#gtceu:batteries/mv',
+			'ae2:fluid_cell_housing')
+		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144))
+		.itemOutputs('ae2:portable_fluid_cell_256k')
+		.duration(200)
+		.EUt(122880)
+		.dimension('ad_astra:moon'))
 
 	//#endregion
 
@@ -1541,6 +1642,7 @@ const registerAE2Recipes = (event) => {
 		.dimension('ad_astra:moon')
 		.circuit(1)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:logic_processor_cr')
 		.itemInputs(
 			'8x ae2:printed_silicon',
@@ -1553,8 +1655,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20 * 60)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(2)
+		.circuit(2))
 
 	// Calculation Processor
 
@@ -1572,6 +1673,7 @@ const registerAE2Recipes = (event) => {
 		.dimension('ad_astra:moon')
 		.circuit(1)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:calculation_processor_cr')
 		.itemInputs(
 			'8x ae2:printed_silicon',
@@ -1584,8 +1686,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20 * 60)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(2)
+		.circuit(2))
 
 	// Engineering Processor
 
@@ -1603,6 +1704,7 @@ const registerAE2Recipes = (event) => {
 		.dimension('ad_astra:moon')
 		.circuit(1)
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:engineering_processor_cr')
 		.itemInputs(
 			'8x ae2:printed_silicon',
@@ -1615,8 +1717,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20 * 60)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(2)
+		.circuit(2))
 
 	// Printed Calculation Processor
 	event.recipes.gtceu.forming_press('ae2:printed_calculation_processor')
@@ -1628,6 +1729,7 @@ const registerAE2Recipes = (event) => {
 		.EUt(480)
 		.dimension('ad_astra:moon')
 
+	requiresOxygenation(
 	event.recipes.gtceu.forming_press('ae2:printed_calculation_processor_cr')
 		.itemInputs('#forge:plates/certus_quartz')
 		.notConsumable('ae2:calculation_processor_press')
@@ -1635,8 +1737,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20)
 		.circuit(2)
 		.EUt(480)
-		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+		.dimension('ad_astra:moon'))
 
 	// Printed Engineering Processor
 	event.recipes.gtceu.forming_press('ae2:printed_engineering_processor')
@@ -1648,6 +1749,7 @@ const registerAE2Recipes = (event) => {
 		.EUt(480)
 		.dimension('ad_astra:moon')
 
+	requiresOxygenation(
 	event.recipes.gtceu.forming_press('ae2:printed_engineering_processor_cr')
 		.itemInputs('#forge:plates/diamond')
 		.notConsumable('ae2:engineering_processor_press')
@@ -1655,8 +1757,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20)
 		.circuit(2)
 		.EUt(480)
-		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+		.dimension('ad_astra:moon'))
 
 	// Printed Logic Processor
 	event.recipes.gtceu.forming_press('ae2:printed_logic_processor')
@@ -1668,6 +1769,7 @@ const registerAE2Recipes = (event) => {
 		.EUt(480)
 		.dimension('ad_astra:moon')
 
+	requiresOxygenation(
 	event.recipes.gtceu.forming_press('ae2:printed_logic_processor_cr')
 		.itemInputs('#forge:plates/gold')
 		.notConsumable('ae2:logic_processor_press')
@@ -1675,8 +1777,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20)
 		.circuit(2)
 		.EUt(480)
-		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+		.dimension('ad_astra:moon'))
 
 	// Printed Silicon
 	event.recipes.gtceu.forming_press('ae2:printed_silicon')
@@ -1688,6 +1789,7 @@ const registerAE2Recipes = (event) => {
 		.EUt(480)
 		.dimension('ad_astra:moon')
 
+	requiresOxygenation(
 	event.recipes.gtceu.forming_press('ae2:printed_silicon_cr')
 		.itemInputs('#forge:plates/silicon')
 		.notConsumable('ae2:silicon_press')
@@ -1695,8 +1797,7 @@ const registerAE2Recipes = (event) => {
 		.duration(20)
 		.circuit(2)
 		.EUt(480)
-		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+		.dimension('ad_astra:moon'))
 
 	//#endregion
 
@@ -1894,14 +1995,12 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('ae2:view_cell')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:item_storage_cell_1k')
 		.itemInputs('ae2:item_cell_housing', 'ae2:cell_component_1k')
 		.itemOutputs('ae2:item_storage_cell_1k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:item_storage_cell_4k')
 		.itemInputs('ae2:item_cell_housing', 'ae2:cell_component_4k')
@@ -1936,7 +2035,6 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('ae2:fluid_storage_cell_1k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:fluid_storage_cell_4k')
 		.itemInputs('ae2:fluid_cell_housing', 'ae2:cell_component_4k')
@@ -2086,7 +2184,6 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('ae2:1k_crafting_storage')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:4k_crafting_storage')
 		.itemInputs('ae2:crafting_unit', 'ae2:cell_component_4k')
@@ -2128,52 +2225,42 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('ae2:crafting_unit', 'ae2:engineering_processor')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:1k_crafting_storage_back')
 		.itemInputs('ae2:1k_crafting_storage')
 		.itemOutputs('ae2:crafting_unit', 'ae2:cell_component_1k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:4k_crafting_storage_back')
 		.itemInputs('ae2:4k_crafting_storage')
 		.itemOutputs('ae2:crafting_unit', 'ae2:cell_component_4k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:16k_crafting_storage_back')
 		.itemInputs('ae2:16k_crafting_storage')
 		.itemOutputs('ae2:crafting_unit', 'ae2:cell_component_16k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:64k_crafting_storage_back')
-		.itemInputs(
-			'ae2:64k_crafting_storage')
-		.itemOutputs(
-			'ae2:crafting_unit',
-			'ae2:cell_component_64k')
+		.itemInputs('ae2:64k_crafting_storage')
+		.itemOutputs('ae2:crafting_unit', 'ae2:cell_component_64k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:256k_crafting_storage_back')
 		.itemInputs('ae2:256k_crafting_storage')
 		.itemOutputs('ae2:crafting_unit', 'ae2:cell_component_256k')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	event.recipes.gtceu.packer('ae2:crafting_monitor_back')
 		.itemInputs('ae2:crafting_monitor')
 		.itemOutputs('ae2:crafting_unit', 'ae2:storage_monitor')
 		.duration(10)
 		.EUt(12)
-		.cleanroom(CleanroomType.CLEANROOM)
 
 	// Cable Anchor
 	event.recipes.gtceu.extruder('ae2:cable_anchor')
@@ -2195,6 +2282,7 @@ const registerAE2Recipes = (event) => {
 		.inputFluids(Fluid.of('tfg:fluix', 144 * 200))
 		.inputFluids(Fluid.of('tfg:cryogenized_fluix', 144 * 150))
 		.itemOutputs('ae2:quantum_ring')
+		.dimension('ad_astra:moon')
 		.duration(900)
 		.EUt(GTValues.VA[GTValues.ZPM])
 		.cleanroom(CleanroomType.CLEANROOM)
@@ -2224,6 +2312,7 @@ const registerAE2Recipes = (event) => {
 		.itemOutputs('ae2:quantum_link')
 		.duration(700)
 		.EUt(GTValues.VA[GTValues.UHV])
+		.cleanroom(CleanroomType.CLEANROOM)
 
 	// Chemical Reactor
 	event.recipes.gtceu.chemical_reactor('ae2:fluix_pearl')

--- a/kubejs/server_scripts/extended_ae2/recipes.js
+++ b/kubejs/server_scripts/extended_ae2/recipes.js
@@ -25,7 +25,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_interface_iv_moon')
 		.itemInputs(
-			'gtceu:iv_electric_motor',
+			'gtceu:iv_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -44,7 +44,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_interface_zpm_cr')
 		.itemInputs(
-			'gtceu:zpm_electric_motor',
+			'gtceu:zpm_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -65,7 +65,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:interface_upgrade_iv_moon')
 		.itemInputs(
-			'gtceu:iv_electric_motor',
+			'gtceu:iv_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -83,7 +83,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:interface_upgrade_zpm')
 		.itemInputs(
-			'gtceu:zpm_electric_motor',
+			'gtceu:zpm_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -145,7 +145,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_pattern_provider_iv')
 		.itemInputs(
-			'gtceu:iv_conveyor_module',
+			'gtceu:iv_robot_arm',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -164,7 +164,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_pattern_provider_zpm')
 		.itemInputs(
-			'gtceu:zpm_conveyor_module',
+			'gtceu:zpm_robot_arm',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -184,7 +184,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:pattern_provider_upgrade_iv_moon')
 		.itemInputs(
-			'gtceu:iv_conveyor_module',
+			'gtceu:iv_robot_arm',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -201,7 +201,7 @@ const registerExtendedAE2Recipes = (event) => {
 	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:pattern_provider_upgrade_zpm')
 		.itemInputs(
-			'gtceu:zpm_conveyor_module',
+			'gtceu:zpm_robot_arm',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',

--- a/kubejs/server_scripts/extended_ae2/recipes.js
+++ b/kubejs/server_scripts/extended_ae2/recipes.js
@@ -13,14 +13,19 @@ const registerExtendedAE2Recipes = (event) => {
 		], mod: 'expatternprovider'
 	});
 
+	function requiresOxygenation(recipe) {
+		TFGRecipeSchemaBindings.isOxygenated(recipe, true)
+	}
+
 
 	//#region Ext Interface
 
 	// IV
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_interface_iv_moon')
 		.itemInputs(
-			'gtceu:iv_conveyor_module',
+			'gtceu:iv_electric_motor',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -32,14 +37,14 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*80)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(5)
+		.circuit(5))
 
 	// ZPM CR
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_interface_zpm_cr')
 		.itemInputs(
-			'gtceu:zpm_conveyor_module',
+			'gtceu:zpm_electric_motor',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -50,17 +55,17 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs('8x expatternprovider:ex_interface')
 		.duration(20*1600)
 		.EUt(GTValues.VA[GTValues.LuV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(6)
-		.dimension('ad_astra:moon')
+		.dimension('ad_astra:moon'))
 
 	// Interface Upgrade
 
 	// IV
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:interface_upgrade_iv_moon')
 		.itemInputs(
-			'gtceu:iv_conveyor_module',
+			'gtceu:iv_electric_motor',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -70,15 +75,15 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs('1x expatternprovider:interface_upgrade')
 		.duration(20*80)
 		.EUt(GTValues.VA[GTValues.EV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(6)
+		.circuit(6))
 
 	// ZPM CR
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:interface_upgrade_zpm')
 		.itemInputs(
-			'gtceu:zpm_conveyor_module',
+			'gtceu:zpm_electric_motor',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -88,9 +93,8 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs('8x expatternprovider:interface_upgrade')
 		.duration(20*1600)
 		.EUt(GTValues.VA[GTValues.LuV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(5)
+		.circuit(5))
 
 	//#endregion
 
@@ -98,6 +102,7 @@ const registerExtendedAE2Recipes = (event) => {
 
 	// LuV
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:oversize_interface_iv_moon')
 		.itemInputs(
 			'1x #expatternprovider:extended_interface',
@@ -110,12 +115,12 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs("1x expatternprovider:oversize_interface")
 		.duration(20*160)
 		.EUt(GTValues.VA[GTValues.LuV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(7)
+		.circuit(7))
 
 	// ZPM CR
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:oversize_interface_zpm')
 		.itemInputs(
 			'8x #expatternprovider:extended_interface',
@@ -128,9 +133,8 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs("8x expatternprovider:oversize_interface")
 		.duration(20*480)
 		.EUt(GTValues.VA[GTValues.ZPM])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(8)
+		.circuit(8))
 
 	//#endregion
 
@@ -138,9 +142,10 @@ const registerExtendedAE2Recipes = (event) => {
 
 	// IV
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_pattern_provider_iv')
 		.itemInputs(
-			'gtceu:iv_robot_arm',
+			'gtceu:iv_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -152,14 +157,14 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*80)
 		.EUt(GTValues.VA[GTValues.EV])
 		.circuit(5)
-		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+		.dimension('ad_astra:moon'))
 
 	// ZPM
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('tfg:ex_pattern_provider_zpm')
 		.itemInputs(
-			'gtceu:zpm_robot_arm',
+			'gtceu:zpm_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -170,17 +175,16 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs('8x expatternprovider:ex_pattern_provider')
 		.duration(20*160)
 		.EUt(GTValues.VA[GTValues.LuV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(6)
+		.circuit(6))
 
 	// Pattern Provider Upgrade
 
 	// IV
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:pattern_provider_upgrade_iv_moon')
 		.itemInputs(
-			'gtceu:iv_robot_arm',
+			'gtceu:iv_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/tungsten_steel',
 			'2x ae2:annihilation_core',
@@ -191,14 +195,13 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*80)
 		.EUt(GTValues.VA[GTValues.EV])
 		.circuit(6)
-		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+		.dimension('ad_astra:moon'))
 
 	// ZPM CR
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:pattern_provider_upgrade_zpm')
 		.itemInputs(
-			'gtceu:zpm_robot_arm',
+			'gtceu:zpm_conveyor_module',
 			'4x gtceu:laminated_glass',
 			'2x #forge:plates/naquadah_alloy',
 			'2x ae2:annihilation_core',
@@ -208,15 +211,15 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs('8x expatternprovider:pattern_provider_upgrade')
 		.duration(20*160)
 		.EUt(GTValues.VA[GTValues.LuV])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(5)
+		.circuit(5))
 
 	//#endregion
 
 	//#region bus
 
 	//ex import bus part
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ex_import_bus_part')
 		.itemInputs(
 			'1x #forge:plates/titanium',
@@ -228,11 +231,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(1)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//ex export bus part
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ex_export_bus_part')
 		.itemInputs(
 			'1x #forge:plates/titanium',
@@ -244,11 +247,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(2)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//tag export bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:tag_export_bus')
 		.itemInputs(
 			'expatternprovider:ex_export_bus_part',
@@ -258,11 +261,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(1)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//tag storage bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:tag_storage_bus')
 		.itemInputs(
 			'ae2:storage_bus',
@@ -272,11 +275,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(2)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//mod export bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:mod_export_bus')
 		.itemInputs(
 			'ae2:export_bus',
@@ -286,11 +289,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(3)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//mod storage bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:mod_storage_bus')
 		.itemInputs(
 			'ae2:storage_bus',
@@ -300,11 +303,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(3)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//precise export bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:precise_export_bus')
 		.itemInputs(
 			'ae2:export_bus',
@@ -314,11 +317,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(4)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//precise storage bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:precise_storage_bus')
 		.itemInputs(
 			'ae2:storage_bus',
@@ -328,11 +331,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(4)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//threshold export bus
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:threshold_export_bus')
 		.itemInputs(
 			'ae2:export_bus',
@@ -342,13 +345,13 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(4)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//#endregion
 
 	//active formation plane
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:active_formation_plane')
 		.itemInputs(
 			'ae2:formation_plane',
@@ -358,9 +361,8 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(8)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//pattern modifier
 	event.recipes.gtceu.assembler('expatternprovider:pattern_modifier')
@@ -374,6 +376,7 @@ const registerExtendedAE2Recipes = (event) => {
 		.addMaterialInfo(true)
 
 	//threshold level emitter
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:threshold_level_emitter')
 		.itemInputs(
 			'ae2:level_emitter',
@@ -383,9 +386,8 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*30)
 		.EUt(GTValues.VA[GTValues.HV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(9)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//wireless tool
 	event.recipes.gtceu.assembler('expatternprovider:wireless_tool')
@@ -411,6 +413,7 @@ const registerExtendedAE2Recipes = (event) => {
 		.EUt(1920)
 
 	//wireless tool
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:wireless_connect')
 		.itemInputs(
 			'2x gtceu:iv_machine_casing',
@@ -424,9 +427,8 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*120)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(9)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//me packing tape
 	event.recipes.gtceu.assembler('expatternprovider:me_packing_tape')
@@ -488,6 +490,7 @@ const registerExtendedAE2Recipes = (event) => {
 	//#region ex molecular assembler
 
 	// IV
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ex_molecular_assembler_iv')
 		.itemInputs(
 			'2x #gtceu:circuits/iv',
@@ -501,10 +504,10 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*180)
 		.EUt(GTValues.VA[GTValues.IV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(5)
+		.circuit(5))
 
 	// ZPM CR
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ex_molecular_assembler_zpm')
 		.itemInputs(
 			'2x #gtceu:circuits/zpm',
@@ -517,13 +520,13 @@ const registerExtendedAE2Recipes = (event) => {
 		.itemOutputs('8x expatternprovider:ex_molecular_assembler')
 		.duration(20*740)
 		.EUt(GTValues.VA[GTValues.ZPM])
-		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
-		.circuit(6)
+		.circuit(6))
 
 	//#endregion
 
 	//ex io port
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ex_io_port')
 		.itemInputs(
 			'gtceu:ev_machine_casing',
@@ -536,10 +539,10 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*120)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(8)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ex_drive')
 		.itemInputs(
 			'gtceu:ev_machine_casing',
@@ -552,10 +555,10 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(9)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:drive_upgrade')
 		.itemInputs(
 			'gtceu:ev_machine_casing',
@@ -567,26 +570,25 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*60)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(8)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:ingredient_buffer')
 		.itemInputs('gtceu:hv_buffer', 'ae2:cell_component_1k')
 		.itemOutputs('expatternprovider:ingredient_buffer')
 		.duration(20*45)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(8)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//#endregion
 
 	//#region Matrix
 
 	//Frame
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:assembler_matrix_frame_moon')
 		.itemInputs(
 			'8x gtceu:plascrete',
@@ -602,11 +604,10 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*120)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(9)
+		.circuit(9))
 
 	//Matrix Wall
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler('expatternprovider:assembler_matrix_wall_luv')
 		.itemInputs(
 			'#forge:frames/polytetrafluoroethylene',
@@ -618,12 +619,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*100)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(1)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//Matrix Glass
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler("expatternprovider:assembler_matrix_glass")
 		.itemInputs(
 			'#forge:frames/polytetrafluoroethylene',
@@ -635,12 +635,11 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20*100)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.circuit(2)
-		.addMaterialInfo(true, true)
+		.addMaterialInfo(true, true))
 
 	//Matrix Pattern
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler("expatternprovider:assembler_matrix_pattern")
 		.itemInputs(
 			'#expatternprovider:extended_pattern_provider',
@@ -655,11 +654,10 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20 * 180)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(7)
+		.circuit(7))
 
 	//Matrix Crafter
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler("expatternprovider:assembler_matrix_crafter")
 		.itemInputs(
 			"#expatternprovider:oversize_interface",
@@ -674,11 +672,10 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20 * 180)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(7)
+		.circuit(7))
 
 	//Matrix Speed
-
+	requiresOxygenation(
 	event.recipes.gtceu.me_assembler("expatternprovider:assembler_matrix_speed_luv")
 		.itemInputs(
 			"megacells:mega_crafting_accelerator",
@@ -693,8 +690,7 @@ const registerExtendedAE2Recipes = (event) => {
 		.duration(20 * 180)
 		.EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-		.circuit(7)
+		.circuit(7))
 
 	event.shaped('expatternprovider:fishbig', [
 		'CCC',

--- a/kubejs/server_scripts/me_requester/recipes.js
+++ b/kubejs/server_scripts/me_requester/recipes.js
@@ -6,6 +6,7 @@ const registerMERequesterRecipes = (event) => {
 	event.remove({ id: 'merequester:requester' })
 
 	// ME Requester
+	TFGRecipeSchemaBindings.isOxygenated(
 	event.recipes.gtceu.me_assembler('tfg:merequester/merequester')
 		.itemInputs(
 			'expatternprovider:ex_pattern_provider',
@@ -21,7 +22,7 @@ const registerMERequesterRecipes = (event) => {
 		.cleanroom(CleanroomType.CLEANROOM)
 		.dimension('ad_astra:moon')
 		.addMaterialInfo(true)
-		.circuit(9)
+		.circuit(9), true)
 
 	// ME Requester Terminal
 	event.shaped('merequester:requester_terminal', [

--- a/kubejs/server_scripts/mega_cells/recipes.js
+++ b/kubejs/server_scripts/mega_cells/recipes.js
@@ -9,24 +9,27 @@ const registerMegaCellsRecipes = (event) => {
         {id: 'megacells:network/mega_interface_part'},
         {id: 'megacells:network/mega_pattern_provider_part'},
     ], mod: 'megacells' })
+    
+	function requiresOxygenation(recipe) {
+		TFGRecipeSchemaBindings.isOxygenated(recipe, true)
+	}
 
     // Energy Cell
-    
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:mega_energy_cell')
         .itemInputs('8x ae2:dense_energy_cell', '8x gtceu:nichrome_quadruple_wire', '4x #gtceu:circuits/iv')
         .itemOutputs('megacells:mega_energy_cell')
         .duration(20*240)
         .EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
 		.addMaterialInfo(true)
-        .circuit(9)
+        .circuit(9))
 
     // Pattern Provider
-
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('tfg:mega_pattern_provider')
 		.itemInputs(
-			'gtceu:ev_robot_arm',
+			'gtceu:ev_conveyor_module',
 			'gtceu:stainless_steel_crate',
 			'4x #forge:plates/stainless_steel',
 			'4x ae2:annihilation_core',
@@ -40,27 +43,18 @@ const registerMegaCellsRecipes = (event) => {
 		.duration(20 * 80)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.circuit(3)
+		.circuit(3))
 
     //printed accumulation circuit
-    event.recipes.gtceu.forming_press('megacells:printed_accumulation_processor_moon')
+    requiresOxygenation(
+    event.recipes.gtceu.forming_press('megacells:printed_accumulation_processor')
         .itemInputs('#forge:dense_plates/silicon')
         .notConsumable('megacells:accumulation_processor_press')
         .itemOutputs('megacells:printed_accumulation_processor')
         .duration(20)
-        .circuit(1)
-        .EUt(GTValues.VA[GTValues.IV])
-        .dimension('ad_astra:moon')
-
-    event.recipes.gtceu.forming_press('megacells:printed_accumulation_processor_cr')
-        .itemInputs('#forge:dense_plates/silicon')
-        .notConsumable('megacells:accumulation_processor_press')
-        .itemOutputs('2x megacells:printed_accumulation_processor')
-        .duration(20)
         .circuit(2)
         .EUt(GTValues.VA[GTValues.IV])
-        .dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
+        .dimension('ad_astra:moon'))
 
 	// Accumulation Processor
 
@@ -78,6 +72,7 @@ const registerMegaCellsRecipes = (event) => {
 		.dimension('ad_astra:moon')
         .circuit(1)
 
+    requiresOxygenation(
 	event.recipes.gtceu.me_assembler('ae2:accumulation_processor_cr')
 		.itemInputs(
 			'ae2:printed_silicon',
@@ -90,8 +85,7 @@ const registerMegaCellsRecipes = (event) => {
 		.duration(20*80)
 		.EUt(GTValues.VA[GTValues.EV])
 		.dimension('ad_astra:moon')
-		.cleanroom(CleanroomType.CLEANROOM)
-        .circuit(2)
+        .circuit(2))
 
     // Inscriber Silicon Press
     event.recipes.gtceu.laser_engraver('ae2:accumulation_processor_press')
@@ -113,7 +107,7 @@ const registerMegaCellsRecipes = (event) => {
 		.EUt(GTValues.VA[GTValues.IV])
 
     //Mega Item Cell Housing
-
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:mega_item_cell_housing')
         .itemInputs(
  			'1x #gtceu:circuits/iv',
@@ -129,12 +123,11 @@ const registerMegaCellsRecipes = (event) => {
         .duration(20*60)
         .EUt(GTValues.VA[GTValues.IV])
 		.dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
         .addMaterialInfo(true)
-        .circuit(6)
+        .circuit(6))
     
     //Mega Fluid Cell Housing
-    
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:mega_fluid_cell_housing')
         .itemInputs(
  			'1x #gtceu:circuits/iv',
@@ -150,9 +143,8 @@ const registerMegaCellsRecipes = (event) => {
         .duration(20*60)
         .EUt(GTValues.VA[GTValues.IV])
 		.dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
         .addMaterialInfo(true)
-        .circuit(6)
+        .circuit(6))
 
     //cell dock
     event.recipes.gtceu.shaped('megacells:cell_dock', [
@@ -168,6 +160,7 @@ const registerMegaCellsRecipes = (event) => {
     //#region Storage Components
 
     // 1m storage components
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:cell_component_1m')
         .itemInputs(
  			'4x #gtceu:circuits/zpm',
@@ -187,10 +180,10 @@ const registerMegaCellsRecipes = (event) => {
         .duration(20*100)
         .EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
-        .circuit(6)
+        .circuit(6))
 
     // 4m storage components
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:cell_component_4m')
         .itemInputs(
  			'4x #gtceu:circuits/uv',
@@ -210,10 +203,10 @@ const registerMegaCellsRecipes = (event) => {
         .duration(20*200)
         .EUt(GTValues.VA[GTValues.LuV])
 		.dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
-        .circuit(7)
+        .circuit(7))
 
     // 16m storage components
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:cell_component_16m')
         .itemInputs(
  			'4x #gtceu:circuits/uhv',
@@ -235,10 +228,10 @@ const registerMegaCellsRecipes = (event) => {
             .CWUt(32))
         .EUt(GTValues.VA[GTValues.ZPM])
         .dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
-        .circuit(8)
+        .circuit(8))
 
     // 64m storage components
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:cell_component_64m')
         .itemInputs(
  			'8x #gtceu:circuits/uhv',
@@ -260,8 +253,7 @@ const registerMegaCellsRecipes = (event) => {
             .CWUt(64))
         .EUt(GTValues.VA[GTValues.UV])
         .dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
-        .circuit(9)
+        .circuit(9))
 
     // greater energy card
     event.recipes.gtceu.assembler('megacells:greater_energy_card')
@@ -421,6 +413,7 @@ const registerMegaCellsRecipes = (event) => {
 
     //#region Crafting Unit
 
+    requiresOxygenation(
     event.recipes.gtceu.me_assembler('megacells:mega_crafting_unit')
         .itemInputs(
             '4x megacells:accumulation_processor',
@@ -435,8 +428,7 @@ const registerMegaCellsRecipes = (event) => {
         .duration(20*160)
         .EUt(GTValues.VA[GTValues.IV])
         .dimension('ad_astra:moon')
-        .cleanroom(CleanroomType.CLEANROOM)
-        .circuit(3)
+        .circuit(3))
 
 
     // Mega Crafting  Storage

--- a/kubejs/server_scripts/mega_cells/recipes.js
+++ b/kubejs/server_scripts/mega_cells/recipes.js
@@ -29,7 +29,7 @@ const registerMegaCellsRecipes = (event) => {
     requiresOxygenation(
     event.recipes.gtceu.me_assembler('tfg:mega_pattern_provider')
 		.itemInputs(
-			'gtceu:ev_conveyor_module',
+			'gtceu:ev_robot_arm',
 			'gtceu:stainless_steel_crate',
 			'4x #forge:plates/stainless_steel',
 			'4x ae2:annihilation_core',

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -139,13 +139,13 @@ const registerRailWaysRecipes = (event) => {
 		'AAA',
 		'ACA'
 		], {
-		A: '#forge:rods/long/steel',
+		A: '#forge:rods/long/wood',
 		B: 'railways:small_buffer',
 		C: '#forge:tools/hammers'
 	}).id('railways:shaped/buffer')
 
 	event.recipes.gtceu.assembler(`tfg:railways/buffer`)
-		.itemInputs(`6x #forge:rods/long/steel`, `2x railways:small_buffer`)
+		.itemInputs(`6x #forge:rods/long/wood`, `2x railways:small_buffer`)
 		.circuit(1)
 		.itemOutputs(`railways:buffer`)
 		.duration(200)


### PR DESCRIPTION
- Changed all of the ME assembler cleanroom recipes to require oxygenation instead
- Left the cleanroom recipes for the assembler/packer alone, except for the 1ks
- Changed interfaces to use motors instead of conveyors, and changed patprovs to use conveyors instead of robot arms, which should help with the price complaints (left extended and oversize interfaces alone)
- Removed the extra plates from interfaces and patprovs since you already have the crates being the bigger metal material cost (as they're already 8 ingots each)