### PR TITLE
Stop cyclohexanone oxime from gobbling tin

### DIFF
--- a/kubejs/server_scripts/tfg/powergen/nuclear/recipes.smr_additives.js
+++ b/kubejs/server_scripts/tfg/powergen/nuclear/recipes.smr_additives.js
@@ -24,10 +24,10 @@ function registerTFGSMRAdditives(event) {
 		.EUt(GTValues.VA[GTValues.HV])
 		
 	event.recipes.gtceu.chemical_reactor('tfg:cyclohexanone_add_oxime')
-		.itemInputs('#forge:dusts/tin')
 		.inputFluids(Fluid.of('tfg:cyclohexanone', 1000), Fluid.of('gtceu:ammonia', 1000), Fluid.of('gtceu:hydrogen_peroxide', 1000))
 		.itemOutputs('19x #forge:dusts/cyclohexanone_oxime')
 		.outputFluids(Fluid.of('minecraft:water', 2000))
+		.notConsumable('#forge:dusts/tin')
 		.duration(200)
 		.EUt(GTValues.VA[GTValues.HV])
 		


### PR DESCRIPTION
Changed the tin dust in the recipe for cyclohexanone oxime starting with cyclohexanone from a standard item input to a non-consumable one.

