### PR TITLE
fix: make modded eggs usable in heating devices

### DIFF
--- a/kubejs/server_scripts/tfg/food/data.food.js
+++ b/kubejs/server_scripts/tfg/food/data.food.js
@@ -136,6 +136,9 @@ function registerTFGFoodData(event) {
 	});
 
 	// Eggs
+	event.itemHeat('species:birt_egg', 1, null, null);
+	event.itemHeat('#tfg:martian_eggs', 1, null, null);
+
 	/**
 	 * Array of egg items to get food data. 
 	 * Do not register eggs that can be fertilized here. Those items dynamically change expiration time.

--- a/kubejs/server_scripts/tfg/food/data.food.js
+++ b/kubejs/server_scripts/tfg/food/data.food.js
@@ -136,11 +136,8 @@ function registerTFGFoodData(event) {
 	});
 
 	// Eggs
-	event.itemHeat('species:birt_egg', 1, null, null);
-	event.itemHeat('#tfg:martian_eggs', 1, null, null);
-
 	/**
-	 * Array of egg items to get food data. 
+	 * Array of egg items to get food and heat data.
 	 * Do not register eggs that can be fertilized here. Those items dynamically change expiration time.
 	 * @type {{String<Item>}}
 	 */
@@ -161,6 +158,7 @@ function registerTFGFoodData(event) {
 		'species:springling_egg'
 	];
 	eggItems.forEach(egg => {
+		event.itemHeat(egg, 1, null, null);
 		event.foodItem(egg, food => {
 			food.decayModifier(2)
 		});


### PR DESCRIPTION
Adds TFC heat data to the existing egg item list so supported bird eggs can be inserted into campfires, charcoal forges, and ovens and cooked by the recipe already shown in EMI.

Fixes #4867

AI use disclosure: Codex was used to investigate, implement, and check this change.
