### PR TITLE
fix treated wood barrel recipes accepting their own output as input

### DIFF
--- a/kubejs/server_scripts/tfg/primitive/recipes.wood.js
+++ b/kubejs/server_scripts/tfg/primitive/recipes.wood.js
@@ -56,8 +56,8 @@ function registerTFGWoodRecipes(event) {
 
 	TREATED_WOOD_ITEMS.forEach(item => {
 		event.recipes.tfc.barrel_sealed(1000 * item.multiplier)
-			.outputItem(`${item.output}`)
-			.inputs(`${item.input}`, TFC.fluidStackIngredient('#forge:creosote', 25 * item.multiplier))
+			.outputItem(item.output)
+			.inputs(Ingredient.of(item.input).subtract(item.output), TFC.fluidStackIngredient('#forge:creosote', 25 * item.multiplier))
 			.id(`tfg:barrel/${global.linuxUnfucker(item.output)}`)
 	})
 


### PR DESCRIPTION
## What is the new behavior?

Sealed barrel recipes for treated wood don't accept their own output as input anymore.

Before this the barrel would finish a recipe and start over on the item it just made, using all the creosote in there.

## Implementation Details

The cause is that most treated wood items live in the exact tag their own recipe takes as input so the output is always a valid input. So inside the loop that goes throught TREATED_WOOD_ITEMS and add the recipes I removed the outputs from the input tags with tag subtraction.

## Outcome

Close #4533

## Additional Information

Tested in game: put wood sticks in a creosote barrel, it makes the treated wood sticks and stops.

---

Discord: ari3x_
