### PR TITLE
Fix assembler burlap sack collision with wool yarn

### DIFF
--- a/kubejs/server_scripts/sacksnstuff/recipes.js
+++ b/kubejs/server_scripts/sacksnstuff/recipes.js
@@ -39,7 +39,7 @@ const registerSNSRecipes = (event) => {
 		)
 		.itemOutputs('sns:burlap_sack')
 		.duration(100)
-		.circuit(4)
+		.circuit(6)
 		.EUt(GTValues.VA[GTValues.LV])
 	
 	event.recipes.tfc.sewing(


### PR DESCRIPTION
## What is the new behavior?
Fixes circuit collision of burlap sack with wool yarn to wool on circuit condition 4.

## Outcome
Wool yarn from burlap sack recipe does not turn into wool

## Additional Information
Only collision in circuit condition 6 is repairing iron flask (complex cloth recipe without wool yarn, or any other string)