### PR TITLE
Fix missing multiblock in zh_cn Firmaciv canoe guide

### DIFF
--- a/kubejs/assets/tfc/patchouli_books/field_guide/zh_cn/entries/firmaciv/canoe.json
+++ b/kubejs/assets/tfc/patchouli_books/field_guide/zh_cn/entries/firmaciv/canoe.json
@@ -23,7 +23,23 @@
     },
     {
       "type": "patchouli:multiblock",
-      "text": "制作独木舟的第一步"
+      "multiblock": {
+        "pattern": [
+          [
+            " F ",
+            " 0 ",
+            " B "
+          ]
+        ],
+        "mapping": {
+          "F": "tfc:wood/stripped_log/douglas_fir[axis=x]",
+          "0": "tfc:wood/stripped_log/douglas_fir[axis=x]",
+          "B": "tfc:wood/stripped_log/douglas_fir[axis=x]"
+        }
+      },
+      "name": "原木",
+      "text": "制作独木舟的第一步。",
+      "enable_visualize": false
     },
     {
       "type": "patchouli:multiblock",


### PR DESCRIPTION
## What is the new behavior?

Fixes the Simplified Chinese (`zh_cn`) TFC Field Guide entry for FirmaCiv's dugout canoe.

The `zh_cn` version of `firmaciv/canoe.json` is missing the `multiblock` definition on the first `patchouli:multiblock` page. This causes Patchouli to throw:

`java.lang.IllegalArgumentException: No multiblock located for null`

and the entire `tfc:field_guide` is loaded with empty contents.

The English (`en_us`) entry contains the correct multiblock definition, so this PR restores the missing structure in the Chinese entry while keeping the translated text.

## Implementation Details

Copied the missing `multiblock` structure and related page properties from the corresponding `en_us` entry into the `zh_cn` entry.

No gameplay logic or mod code is changed.

## Outcome

The Simplified Chinese TFC Field Guide can load normally again instead of appearing completely empty when the FirmaCiv canoe entry is compiled.

## Additional Information

Relevant Patchouli error:

`Error while building entry tfc:firmaciv/canoe page 4 of book tfc:field_guide`

`Caused by: java.lang.IllegalArgumentException: No multiblock located for null`

## Potential Compatibility Issues

None expected. This only fixes malformed Patchouli book data in the `zh_cn` localization and matches the structure already used by the `en_us` entry.
