### PR TITLE
Added an exclusion for voxy lod to ftbbackup config

### DIFF
--- a/.pakku/server-overrides/config/ftbbackups2.json
+++ b/.pakku/server-overrides/config/ftbbackups2.json
@@ -66,7 +66,8 @@
 	   *path/contains*                 Any files who's path contains
 	*/
 	"excluded": [
-		"DistantHorizons.sqlite"
+		"DistantHorizons.sqlite",
+		"*voxy*"
 	],
 	// The dimension used when creating backup preview image, specify "all" to enable automatic detection of primary dimension (can be very slow)
 	"preview_dimension": "minecraft:overworld"

--- a/config/ftbbackups2.json
+++ b/config/ftbbackups2.json
@@ -72,7 +72,8 @@
 	   *path/contains*                 Any files who's path contains
 	*/
 	"excluded": [
-		"DistantHorizons.sqlite"
+		"DistantHorizons.sqlite",
+		"*voxy*"
 	],
 	// The dimension used when creating backup preview image, specify "all" to enable automatic detection of primary dimension (can be very slow)
 	"preview_dimension": "minecraft:overworld"


### PR DESCRIPTION
## What is the new behavior?
I have been playing with voxy for a while (it is working pretty well).
Only issue is that voxy lod are located in the save folder so that made backup zip way bigger then needed (and slower)
I simply added an exclusion to ftbbackup

## Implementation Details
Unless voxy is use by another mod/minecraft, there is no real reason for concern

## Outcome
Added an exclusion for voxy lod to ftbbackup config so they aren't in the backup zip

## Additional Information
nothing

## Potential Compatibility Issues
Nothing